### PR TITLE
Added CRV PEs per layer per side  

### DIFF
--- a/inc/CrvHitInfoReco.hh
+++ b/inc/CrvHitInfoReco.hh
@@ -21,13 +21,13 @@ namespace mu2e
     float             time = -1; // average hit time
     float             PEs = -1;   //total number of PEs for this cluster
     std::array<float, CRVId::nLayers> PEsPerLayer = {-1};  // PEs per layer for this cluster
-    std::array<std::array<float, CRVId::nSidesPerBar>, CRVId::nLayers> PEsPerLayerPerSide = {-1}; // PEs per layer per side for this cluster
+    std::array<float, CRVId::nLayers * CRVId::nSidesPerBar> sidePEsPerLayer = {-1};// PEs per layer per side for this cluster
     int               nHits = -1;      //number of coincidence hits in this cluster
     int               nLayers = -1;      //number of coincidence layers in this cluster
     float             angle = -999;   //coincidence direction
 
     CrvHitInfoReco(){}
-    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, std::array<std::array<float, CRVId::nSidesPerBar>, CRVId::nLayers> PEsPerLayerPerSide, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle);
+    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, std::array<float, CRVId::nLayers * CRVId::nSidesPerBar> sidePEsPerLayer, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle);
   };
   typedef std::vector<CrvHitInfoReco> CrvHitInfoRecoCollection;  //this is the reco vector which will be stored in the main TTree
 }

--- a/inc/CrvHitInfoReco.hh
+++ b/inc/CrvHitInfoReco.hh
@@ -21,12 +21,13 @@ namespace mu2e
     float             time = -1; // average hit time
     float             PEs = -1;   //total number of PEs for this cluster
     std::array<float, CRVId::nLayers> PEsPerLayer = {-1};  // PEs per layer for this cluster
+    std::array<std::array<float, CRVId::nSidesPerBar>, CRVId::nLayers> PEsPerLayerPerSide = {-1}; // PEs per layer per side for this cluster
     int               nHits = -1;      //number of coincidence hits in this cluster
     int               nLayers = -1;      //number of coincidence layers in this cluster
     float             angle = -999;   //coincidence direction
 
     CrvHitInfoReco(){}
-    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle);
+    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, std::array<std::array<float, CRVId::nSidesPerBar>, CRVId::nLayers> PEsPerLayerPerSide, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle);
   };
   typedef std::vector<CrvHitInfoReco> CrvHitInfoRecoCollection;  //this is the reco vector which will be stored in the main TTree
 }

--- a/src/CrvHitInfoReco.cc
+++ b/src/CrvHitInfoReco.cc
@@ -1,7 +1,7 @@
 #include "EventNtuple/inc/CrvHitInfoReco.hh"
 #include "CLHEP/Vector/ThreeVector.h"
 namespace mu2e {
-  CrvHitInfoReco::CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
+  CrvHitInfoReco::CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, std::array<std::array<float, CRVId::nSidesPerBar>, CRVId::nLayers> PEsPerLayerPerSide, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
     sectorType(sectorType),
     pos(hpos),
     timeStart(timeWindowStart),
@@ -9,6 +9,7 @@ namespace mu2e {
     time(timeAvg),
     PEs(PEs),
     PEsPerLayer(PEsPerLayer),
+    PEsPerLayerPerSide(PEsPerLayerPerSide),
     nHits(nCoincidenceHits),
     nLayers(nCoincidenceLayers),
     angle(coincidenceAngle)

--- a/src/CrvHitInfoReco.cc
+++ b/src/CrvHitInfoReco.cc
@@ -1,7 +1,8 @@
 #include "EventNtuple/inc/CrvHitInfoReco.hh"
 #include "CLHEP/Vector/ThreeVector.h"
 namespace mu2e {
-  CrvHitInfoReco::CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, std::array<std::array<float, CRVId::nSidesPerBar>, CRVId::nLayers> PEsPerLayerPerSide, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
+  CrvHitInfoReco::CrvHitInfoReco(int nCoincs, int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindlsowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, std::array<float, CRVId::nLayers * CRVId::nSidesPerBar> sidePEsPerLayer, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
+    nCoincs(nCoincs),
     sectorType(sectorType),
     pos(hpos),
     timeStart(timeWindowStart),
@@ -9,7 +10,7 @@ namespace mu2e {
     time(timeAvg),
     PEs(PEs),
     PEsPerLayer(PEsPerLayer),
-    PEsPerLayerPerSide(PEsPerLayerPerSide),
+    sidePEsPerLayer(sidePEsPerLayer),
     nHits(nCoincidenceHits),
     nLayers(nCoincidenceLayers),
     angle(coincidenceAngle)

--- a/src/CrvInfoHelper.cc
+++ b/src/CrvInfoHelper.cc
@@ -31,21 +31,23 @@ namespace mu2e
       CrvPlaneInfoMCCollection &MCInfoPlane, double crvPlaneY) {
     GeomHandle<CosmicRayShield> CRS;
     GeomHandle<DetectorSystem> tdet;
+
     if(!crvCoincidences.isValid()) return;
     size_t nClusters=crvCoincidences->size();
     for(size_t i=0; i<nClusters; i++)
     {
       const CrvCoincidenceCluster &cluster = crvCoincidences->at(i);
-
-      // Get the PEs per layer from the reco pulses
-      std::array<float, CRVId::nLayers> PEsPerLayer_ = {0.}; // PEs per layer array, each element initiliased to zero
-      std::array<std::array<float, CRVId::nSidesPerBar>, CRVId::nLayers> PEsPerLayerPerSide_ = {0.}; // 2D PEs per layer per SiPM array, length fixed to CRVId::nLayers, each element initiliased to zero
       const std::vector<art::Ptr<CrvRecoPulse> > coincRecoPulses_ = cluster.GetCrvRecoPulses(); // Get the reco pulses from the coincidence 
-      
+      // Initiliase PEs per layer
+      std::array<float, CRVId::nLayers> PEsPerLayer_ = {0.}; 
+      // Initiliase PEs per layer per side
+      std::array<float, CRVId::nLayers * CRVId::nSidesPerBar> sidePEsPerLayer_ = {0.};
       for(size_t j=0; j<coincRecoPulses_.size(); j++) // Loop through the pulses
       {
         // Skip duplicate pulses (those with multiple peaks)
         if(coincRecoPulses_.at(j)->GetRecoPulseFlags().test(CrvRecoPulseFlagEnums::duplicateNoFitPulse)) continue;
+        // Get PEs associated with this reco pulse
+        float PEs = coincRecoPulses_.at(j)->GetPEsNoFit();
         // Get layer number from the bar index associated with this reco pulse
         const CRSScintillatorBarIndex &crvBarIndex = coincRecoPulses_.at(j)->GetScintillatorBarIndex(); 
         const CRSScintillatorBar &crvCounter = CRS->getBar(crvBarIndex);
@@ -55,11 +57,11 @@ namespace mu2e
         // The negative side has SiPM indices 0 and 2, the postive side has indices 1 and 3.
         // zero/one index indicates negative/positive; negative/positive indicates direction wrt the axis in the coordinate system.
         int side = coincRecoPulses_.at(j)->GetSiPMNumber() % CRVId::nSidesPerBar; 
-
         // Sum PEs for this coincidence, indexed by layer number
-        PEsPerLayer_[layerNumber] += coincRecoPulses_.at(j)->GetPEsNoFit(); // The coincidences were found using the NoFit option, so use that here as well  
+        PEsPerLayer_[layerNumber] += PEs; 
         // Sum PEs for this coincidence, indexed by layer number and side number
-        PEsPerLayerPerSide_[layerNumber][side] += coincRecoPulses_.at(j)->GetPEsNoFit(); 
+        int layerSideIndex = layerNumber * CRVId::nSidesPerBar + side; // Indices for a flattened 2D matrix: layers (rows), sides (columns)
+        sidePEsPerLayer_[layerSideIndex] += PEs;
       }
 
       //fill the Reco collection
@@ -68,8 +70,8 @@ namespace mu2e
           tdet->toDetector(cluster.GetAvgHitPos()),
           cluster.GetStartTime(), cluster.GetEndTime(), cluster.GetAvgHitTime(),
           cluster.GetPEs(),
-          PEsPerLayer_, // PEsPerLayer array is not a member of the mu2e::CrvCoincidenceCluster class...
-          PEsPerLayerPerSide_, // ""
+          PEsPerLayer_, // PEsPerLayer array is not a member of the mu2e::CrvCoincidenceCluster class
+          sidePEsPerLayer_, // ""
           cluster.GetCrvRecoPulses().size(),
           cluster.GetLayers().size(),
           cluster.GetSlope());


### PR DESCRIPTION
I have added a new CRV leaf `crvcoincs.sidePEsPerLayer`. This is very similar to `crvcoincs.PEsPerLayer`, but is split by scintillator bar side (bars are usually read from both ends). This was requested by Natalie and Yuri, and is useful for in-situ CRV efficiency studies. 

This leaf is a `std::array` of length eight. It is a flattened 2D matrix of PEs for four layers and two sides, indexed by `layerNumber * CRVId::nSidesPerBar + side`. `layerNumber` goes from 0 to 3 starting from the strongback, and `side` goes from 0 to 1, where 0 represents the negative side wrt the spatial coordinate system and 1 is the positive side. 

Below is an example printout showing one event in the extracted geometry, which illustrates the structure. It also demonstrates how, for modules with a single ended readout (such as the CRV-DS, or sector 2 here), the side with no readout is populated with zeros. 

```
-------------------------------------------------------------------------------------
event: 509
crvcoincs.sectorType: [1, 2, 3]
crvcoincs.PEs: [472.472, 408.293, 486.949]
crvcoincs.PEsPerLayer: [[110.713, 99.088, 130.829, 131.842], [124.113, 51.381, 93.893, 138.906], [124.778, 122.846, 119.837, 119.488]]
crvcoincs.sidePEsPerLayer: [[56.101, 54.612, 40.167, 58.920, 60.409, 70.419, 78.149, 53.694], [124.113, 0.000, 51.381, 0.000, 93.893, 0.000, 138.906, 0.000], [57.051, 67.727, 64.464, 58.382, 65.193, 54.644, 59.586, 59.902]]
-------------------------------------------------------------------------------------
```

Below are histograms for PEs for each layer and side, from a CORSIKA cosmic ray dataset in the standard configuration. The first was produced using both ROOT/C++ and the second was produced using uproot/Python.

![h1_sidePEsPerLayer_CORSIKA_std](https://github.com/user-attachments/assets/59bd27bc-9873-4e17-84d3-4d21ca4e098b)
![h1_CORSIKA_sidePEsPerLayer](https://github.com/user-attachments/assets/d05fa49c-3c60-46ab-a361-fd96b1a89a60)

Extra note: 

Originally, I was using a nested 2D array, but I had some issues with the array being automatically flattened when using `uproot`, so I choose a 1D array to avoid any ambiguity. I also considered using a `std::vector`, which has better internal support in ROOT, but since the length is fixed `std::array` seems to make more sense. )


