### PR TITLE
Handle APR outputs

### DIFF
--- a/fcl/from_mcs-ceSimReco.fcl
+++ b/fcl/from_mcs-ceSimReco.fcl
@@ -1,6 +1,6 @@
 #include "EventNtuple/fcl/from_mcs-mockdata.fcl"
 
-physics.analyzers.EventNtuple.branches : [ @local::DeM ]
+physics.analyzers.EventNtuple.branches : [ @local::De ]
 physics.analyzers.EventNtuple.FillTriggerInfo : false
-physics.EventNtuplePath : [ MergeKKDeM, PBIWeight, TrkQualDeM, TrkPIDDeM ]
+physics.EventNtuplePath : [ MergeKKDe, PBIWeight, TrkQualDe, TrkPIDDe ]
 physics.EventNtupleEndPath : [ EventNtuple, genCountLogger ]

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -29,6 +29,8 @@ TrkQualUmuP          : @local::TrkQual
 TrkQualUmuP.KalSeedPtrCollection : "MergeKKUmuP"
 TrkQualAll          : @local::TrkQual
 TrkQualAll.KalSeedPtrCollection : "MergeKKAll"
+TrkQualDe           : @local::TrkQual
+TrkQualDe.KalSeedPtrCollection : "MergeKKDe"
 
 
 TrkQualProducers : {
@@ -41,6 +43,7 @@ TrkQualProducers : {
   TrkQualUmuM : @local::TrkQualUmuM
   TrkQualUmuP : @local::TrkQualUmuP
   TrkQualAll : @local::TrkQualAll
+  TrkQualDe : @local::TrkQualDe
 }
 TrkQualProducersPath : [ TrkQualDeM, TrkQualUeM, TrkQualDmuM, TrkQualDeP, TrkQualUeP, TrkQualDmuP, TrkQualUmuM, TrkQualUmuP ]
 
@@ -57,9 +60,12 @@ TrkPIDDeM          : @local::TrkPID
 TrkPIDDeM.KalSeedCollection : "KKDeM"
 TrkPIDDeP          : @local::TrkPID
 TrkPIDDeP.KalSeedCollection : "KKDeP"
+TrkPIDDe          : @local::TrkPID
+TrkPIDDe.KalSeedCollection : "KKDe"
 TrkPIDProducers : {
   TrkPIDDeM : @local::TrkPIDDeM
   TrkPIDDeP : @local::TrkPIDDeP
+  TrkPIDDe : @local::TrkPIDDe
 }
 TrkPIDProducersPath : [ TrkPIDDeM, TrkPIDDeP ]
 
@@ -99,6 +105,9 @@ MergeKKOff.KalSeedCollections : [ "KKOffSpill" ]
 MergeKKAll          : @local::MergeKK
 MergeKKAll.KalSeedCollections : ["KKDeM", "KKDeP", "KKUeM", "KKUeP", "KKDmuM", "KKDmuP", "KKUmuM", "KKUmuP", # will go when all new datasets are added
   "KKDe", "KKUe", "KKDmu", "KKUmu" ] # these are the new APR outputs
+MergeKKDe           : @local::MergeKK
+MergeKKDe.KalSeedCollections : [ "KKDe" ]
+
 
 MergeKKDeMCalib : {
   @table::MergeKK
@@ -127,6 +136,7 @@ MergeKKProducers : {
   MergeKKOff : @local::MergeKKOff
   MergeKKAll : @local::MergeKKAll
   MergeKKDeMCalib : @local::MergeKKAll
+  MergeKKDe : @local::MergeKKDe
 }
 MergeKKProducersPath : [ MergeKKAll ]
 MergeKKNoFieldPath : [ MergeKKLine ]
@@ -182,6 +192,11 @@ All : { input : "MergeKKAll"
 DeMCalib : { input : "MergeKKDeMCalib"
   branch : "trk"
   options : { fillMC : true fillHits : true  genealogyDepth : -1 matchDepth : -1 }
+}
+De : { input : "MergeKKDe"
+  branch : "de"
+  options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
+  trkQualTag : "TrkQualDe"
 }
 
 EventNtupleMaker : {

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -97,7 +97,9 @@ MergeKKLine.KalSeedCollections : [ "KKLine" ]
 MergeKKOff          : @local::MergeKK
 MergeKKOff.KalSeedCollections : [ "KKOffSpill" ]
 MergeKKAll          : @local::MergeKK
-MergeKKAll.KalSeedCollections : ["KKDeM", "KKDeP", "KKUeM", "KKUeP", "KKDmuM", "KKDmuP", "KKUmuM", "KKUmuP" ]
+MergeKKAll.KalSeedCollections : ["KKDeM", "KKDeP", "KKUeM", "KKUeP", "KKDmuM", "KKDmuP", "KKUmuM", "KKUmuP", # will go when all new datasets are added
+  "KKDe", "KKUe", "KKDmu", "KKUmu" ] # these are the new APR outputs
+
 MergeKKDeMCalib : {
   @table::MergeKK
   KalSeedCollections : ["KKDeM"]


### PR DESCRIPTION
New datasets MDC202an are being created with the new APR output (see #237). These are charge agnostic and so KalSeedCollection names have changed from "KKDeM"/"KKDeP" to a single "KKDe".

This PR updates the EventNtuple configuration to write these to the EventNtuple and is backwards compatible with previous datasets.

I have tested on 10 events in the following two datasets:
* mcs.mu2e.CeEndpointMix1BBTriggered.MDC2020am_best_v1_3.art (non-APR output)
* mcs.mu2e.CeEndpointMix1BBTriggered.MDC2020an_perfect_v1_3.art (APR output)

and both produce sensible output containing tracks.

I also performed the validation steps. Updates were needed to ```fcl/from_mcs-ceSimReco.fcl``` so that everything passed