### PR TITLE
Fix missing branches for creating reduced ntuples

### DIFF
--- a/utils/rooutil/inc/Event.hh
+++ b/utils/rooutil/inc/Event.hh
@@ -184,6 +184,17 @@ struct Event {
       }
       for (int i_trk = trks_to_remove.size()-1; i_trk >= 0; --i_trk) {
         trk->erase(trk->begin()+trks_to_remove[i_trk]);
+        if (trkmc) { trkmc->erase(trkmc->begin()+trks_to_remove[i_trk]); }
+        if (trksegs) { trksegs->erase(trksegs->begin()+trks_to_remove[i_trk]); }
+        if (trksegsmc) { trksegsmc->erase(trksegsmc->begin()+trks_to_remove[i_trk]); }
+        if (trkcalohit) { trkcalohit->erase(trkcalohit->begin()+trks_to_remove[i_trk]); }
+        if (trkqual) { trkqual->erase(trkqual->begin()+trks_to_remove[i_trk]); }
+        if (trksegpars_lh) { trksegpars_lh->erase(trksegpars_lh->begin()+trks_to_remove[i_trk]); }
+        if (trksegpars_ch) { trksegpars_ch->erase(trksegpars_ch->begin()+trks_to_remove[i_trk]); }
+        if (trksegpars_kl) { trksegpars_kl->erase(trksegpars_kl->begin()+trks_to_remove[i_trk]); }
+        if (trkhits) { trkhits->erase(trkhits->begin()+trks_to_remove[i_trk]); }
+        if (trkhitsmc) { trkhitsmc->erase(trkhitsmc->begin()+trks_to_remove[i_trk]); }
+        if (trkmats) { trkmats->erase(trkmats->begin()+trks_to_remove[i_trk]); }
       }
 
       tracks.erase(newEnd, tracks.end()); // remove only rearranges and returns the new end

--- a/utils/rooutil/inc/RooUtil.hh
+++ b/utils/rooutil/inc/RooUtil.hh
@@ -78,34 +78,34 @@ public:
     dir->cd();
     output_ntuple = new TTree("ntuple", "reduced ntuple");
 
-    output_ntuple->Branch("evtinfo", event->evtinfo);
-    output_ntuple->Branch("evtinfomc", event->evtinfomc);
-    output_ntuple->Branch("hitcount", event->hitcount);
-    output_ntuple->Branch("crvsummary", event->crvsummary);
-    output_ntuple->Branch("crvsummarymc", event->crvsummarymc);
+    if(event->evtinfo) { output_ntuple->Branch("evtinfo", event->evtinfo); }
+    if(event->evtinfomc) { output_ntuple->Branch("evtinfomc", event->evtinfomc); }
+    if(event->hitcount) { output_ntuple->Branch("hitcount", event->hitcount); }
+    if(event->crvsummary) { output_ntuple->Branch("crvsummary", event->crvsummary); }
+    if(event->crvsummarymc) { output_ntuple->Branch("crvsummarymc", event->crvsummarymc); }
 
-    output_ntuple->Branch("trk", event->trk);
-    output_ntuple->Branch("trkmc", event->trkmc);
-    output_ntuple->Branch("trkcalohit", event->trkcalohit);
-    output_ntuple->Branch("trkcalohitmc", event->trkcalohitmc);
-    output_ntuple->Branch("trkqual", event->trkqual);
-    output_ntuple->Branch("trksegs", event->trksegs);
-    output_ntuple->Branch("trksegsmc", event->trksegsmc);
-    output_ntuple->Branch("trksegpars_lh", event->trksegpars_lh);
-    output_ntuple->Branch("trksegpars_ch", event->trksegpars_ch);
-    output_ntuple->Branch("trksegpars_kl", event->trksegpars_kl);
-    output_ntuple->Branch("trkhits", event->trkhits);
-    output_ntuple->Branch("trkhitsmc", event->trkhitsmc);
-    output_ntuple->Branch("trkmats", event->trkmats);
+    if(event->trk) { output_ntuple->Branch("trk", event->trk); }
+    if(event->trkmc) { output_ntuple->Branch("trkmc", event->trkmc); }
+    if(event->trkcalohit) { output_ntuple->Branch("trkcalohit", event->trkcalohit); }
+    if(event->trkcalohitmc) { output_ntuple->Branch("trkcalohitmc", event->trkcalohitmc); }
+    if(event->trkqual) { output_ntuple->Branch("trkqual", event->trkqual); }
+    if(event->trksegs) { output_ntuple->Branch("trksegs", event->trksegs); }
+    if(event->trksegsmc) { output_ntuple->Branch("trksegsmc", event->trksegsmc); }
+    if(event->trksegpars_lh) { output_ntuple->Branch("trksegpars_lh", event->trksegpars_lh); }
+    if(event->trksegpars_ch) { output_ntuple->Branch("trksegpars_ch", event->trksegpars_ch); }
+    if(event->trksegpars_kl) { output_ntuple->Branch("trksegpars_kl", event->trksegpars_kl); }
+    if(event->trkhits) { output_ntuple->Branch("trkhits", event->trkhits); }
+    if(event->trkhitsmc) { output_ntuple->Branch("trkhitsmc", event->trkhitsmc); }
+    if(event->trkmats) { output_ntuple->Branch("trkmats", event->trkmats); }
 
-    output_ntuple->Branch("crvcoincs", event->crvcoincs);
-    output_ntuple->Branch("crvcoincsmc", event->crvcoincsmc);
-    output_ntuple->Branch("crvdigis", event->crvdigis);
-    output_ntuple->Branch("crvpulses", event->crvpulses);
-    output_ntuple->Branch("crvpulsesmc", event->crvpulsesmc);
-    output_ntuple->Branch("crvcoincsmcplane", event->crvcoincsmcplane);
+    if(event->crvcoincs) { output_ntuple->Branch("crvcoincs", event->crvcoincs); }
+    if(event->crvcoincsmc) { output_ntuple->Branch("crvcoincsmc", event->crvcoincsmc); }
+    if(event->crvdigis) { output_ntuple->Branch("crvdigis", event->crvdigis); }
+    if(event->crvpulses) { output_ntuple->Branch("crvpulses", event->crvpulses); }
+    if(event->crvpulsesmc) { output_ntuple->Branch("crvpulsesmc", event->crvpulsesmc); }
+    if(event->crvcoincsmcplane) { output_ntuple->Branch("crvcoincsmcplane", event->crvcoincsmcplane); }
 
-    output_ntuple->Branch("trkmcsim", event->trkmcsim);
+    if(event->trkmcsim) { output_ntuple->Branch("trkmcsim", event->trkmcsim); }
 
   }
 


### PR DESCRIPTION
Natalie found a bug in the ```CreateNtuple.C``` example that was due to not dealing with some of the branches when creating output ntuples. This PR fixes that. Here is the output showing that it is now working:

```
root [2] ntuple->Scan("@trk.size():@trksegs.size()")
************************************
*    Row   * @trk.size * @trksegs. *
************************************
*        0 *         1 *         1 *
*        1 *         1 *         1 *
*        2 *         1 *         1 *
*        3 *         1 *         1 *
*        4 *         1 *         1 *
```