### PR TITLE
Cosmic genids

### DIFF
--- a/src/CrvInfoHelper.cc
+++ b/src/CrvInfoHelper.cc
@@ -164,7 +164,7 @@ namespace mu2e
         if(abs(trajectorySimParticle->pdgId())!=PDGCode::mu_minus) continue;
         const art::Ptr<SimParticle> &trajectoryPrimaryParticle = FindPrimaryParticle(trajectorySimParticle);
         GenId genId = trajectoryPrimaryParticle->genParticle()->generatorId();
-        if(genId==GenId::cosmicToy || genId==GenId::cosmicDYB || genId==GenId::cosmic || genId==GenId::cosmicCRY)
+        if(genId.isCosmic())
         {
           const std::vector<MCTrajectoryPoint> &points = trajectoryIter->second.points();
           if(points.size()<1) continue;

--- a/utils/rooutil/examples/PlotGenCosmicMom.C
+++ b/utils/rooutil/examples/PlotGenCosmicMom.C
@@ -1,0 +1,43 @@
+//
+// An example of how to plot the initial z-position of MCParticle muons
+// This uses cut functions defined in common_cuts.hh
+//
+
+#include "EventNtuple/utils/rooutil/inc/RooUtil.hh"
+#include "EventNtuple/utils/rooutil/inc/common_cuts.hh"
+
+#include "TH1F.h"
+
+void PlotGenCosmicMom(std::string filename) {
+
+  // Create the histogram you want to fill
+  TH1F* hGenCosmicMom = new TH1F("hGenCosmicMom", "", 100,0,5000);
+
+  // Set up RooUtil
+  RooUtil util(filename);
+  //  util.Debug(true);
+  // Loop through the events
+  for (int i_event = 0; i_event < util.GetNEvents(); ++i_event) {
+    // Get the next event
+    auto& event = util.GetEvent(i_event);
+
+    // Get the e_minus tracks from the event
+    auto e_minus_tracks = event.GetTracks(is_e_minus);
+
+    // Loop through the e_minus tracks
+    for (auto& track : e_minus_tracks) {
+
+      // Get the track segments at the tracker entrance and has an MC step
+      auto gen_cosmics = track.GetMCParticles(is_cosmic);
+      // Loop through the tracker entrance track segments
+      for (auto& particle : gen_cosmics) {
+        // Fill the histogram
+        hGenCosmicMom->Fill(particle.mcsim->mom.R());
+      }
+    }
+  }
+
+  // Draw the histogram
+  hGenCosmicMom->SetLineColor(kBlue);
+  hGenCosmicMom->Draw("HIST E");
+}

--- a/utils/rooutil/inc/common_cuts.hh
+++ b/utils/rooutil/inc/common_cuts.hh
@@ -209,6 +209,10 @@ bool from_gen_id(MCParticle& particle, mu2e::GenId::enum_type genid) { // MCPart
   else { return false; }
 }
 
+bool is_cosmic(MCParticle& particle) { // MCParticle is a cosmic. This uses the function GenId::isCosmic() from Offline
+  return mu2e::GenId(mu2e::GenId::enum_type(particle.mcsim->gen)).isCosmic();
+}
+
 //+ MCParticle Cuts - Genealogy
 bool has_track_relationship(MCParticle& particle, mu2e::MCRelationship::relation rel) { // MCParticle has this relationship to track primary
   if (particle.mcsim->trkrel == rel) { return true; }

--- a/validation/test_rooutil_examples.sh
+++ b/validation/test_rooutil_examples.sh
@@ -5,7 +5,8 @@ root -l -b -q utils/rooutil/examples/PrintEvents.C++\(${filename},true\) # speci
 scripts=( "CreateNtuple.C" "CreateTrackNtuple.C" "PlotCRVPEs.C" "PlotCRVPEsVsMCEDep.C" "PlotEntranceFitPars.C" "PlotEntranceMomentum.C"
           "PlotEntranceMomentumCRVCut.C" "PlotEntranceMomentumResolution.C" "PlotEntranceMomentumResolution_TrkQualCut.C"
           "PlotMCParentPosZ.C" "PlotMCParticleMom.C" "PlotMuonPosZ.C" "PlotStoppingTargetFoilSegment.C" "PlotTrackNHits_RecoVsTrue.C"
-          "PlotTrkCaloHitEnergy.C" "PrintEventsNoMC.C" "TrackCounting.C" "PlotTrackHitTimes.C" "PlotTrackHitTimesMC.C" "PlotStrawMaterials.C")
+          "PlotTrkCaloHitEnergy.C" "PrintEventsNoMC.C" "TrackCounting.C" "PlotTrackHitTimes.C" "PlotTrackHitTimesMC.C" "PlotStrawMaterials.C"
+          "PlotGenCosmicMom.C" )
 
 for script in "${scripts[@]}"
 do


### PR DESCRIPTION
@oksuzian pointed out that we are missing ```GenId::cosmicCORSIKA``` in the ```CrvInfoHelper``` check. Looking into it, there is already a ```GenId::isCosmic()``` function in Offline that I will expand in a separate PR.

I have also added a new RooUtil common_cuts function to use ```GenId::isCosmic``` along with an example script.