### PR TITLE
Add versioning + RooUtil: branch protections, debug messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 ## Table of Contents
 1. [Introduction](#Introduction)
 2. [Structure](#Structure)
-3. [How to Analyze an EventNtuple](#How-to-Analyze-an-EventNtuple)
-4. [How to Create an EventNtuple](#How-to-Create-an-EventNtuple)
-5. [Validation](#Validation)
-6. [Notes for Developers](#Notes-for-Developers)
-7. [Previous Verisons](#Previous-Versions)
+3. [How to get the version of EventNtuple](#How-to-get-the-version-of-EventNtuple)
+4. [How to Analyze an EventNtuple](#How-to-Analyze-an-EventNtuple)
+5. [How to Create an EventNtuple](#How-to-Create-an-EventNtuple)
+6. [Validation](#Validation)
+7. [Tagging a New Release](#Tagging-a-New-Release)
+8. [Notes for Developers](#Notes-for-Developers)
+9. [Previous Verisons](#Previous-Versions)
    - [Upgrading from v5 to 6](#Upgrading-from-v5-to-v6)
-8. [Other Useful Links](#Other-Useful-Links)
+10. [Other Useful Links](#Other-Useful-Links)
 
 ## Introduction
 
@@ -21,6 +23,13 @@ The EventNtuple structure is complex. Some branches consist of a single object (
 A [list of branches is available](./doc/branches.md)
 
 The help understand what all the branches and leaves mean, we have an [```ntuplehelper```](doc/ntuplehelper.md) tool
+
+## How to get the version of EventNtuple that is in a file
+For versions of EventNtuple later than v6.3.0, we store the version number in the ROOT file. You can check the version number with the ```checkEventNtuple``` tool:
+
+```
+checkEventNtuple file1.root file2.root
+```
 
 ## How to Analyze an EventNtuple
 To help with analyzing the EventNtuple given its complex structure, we have two sets of utilities:
@@ -47,6 +56,9 @@ Notes for developers contributing to EventNtuple are [here](doc/developers.md)
 
 ## Validation
 Validation scripts and instructions are [here](validation/README.md)
+
+## Tagging a New Release
+Don't forget to set the new version number in ```src/EventNtupleMaker_module.cc```!
 
 ## Previous Versions
 The version history of EventNtuple is [here](https://mu2ewiki.fnal.gov/wiki/EventNtuple).

--- a/bin/checkEventNtuple
+++ b/bin/checkEventNtuple
@@ -22,9 +22,9 @@ def main():
                 folder = f.Get(foldername)
                 if (folder.GetListOfKeys().Contains("version")):
                     h = f.Get("EventNtuple/version")
-                    print("{} contains EventNtuple v{:0.0f}.{:0.0f}.{:0.0f}".format(filename, h.GetBinContent(1), h.GetBinContent(2), h.GetBinContent(3)))
+                    print("{} contains EventNtuple v{:02.0f}_{:02.0f}_{:02.0f}".format(filename, h.GetBinContent(1), h.GetBinContent(2), h.GetBinContent(3)))
                 else:
-                    print("{} histogram does not exist in {} (it is likely older than v6.3.0)".format(histname, filename))
+                    print("{} histogram does not exist in {} (it is v06_02_00 or older)".format(histname, filename))
             else:
                 print("{}/ folder does not exist in {}".format(foldername, filename))
         except OSError:

--- a/bin/checkEventNtuple
+++ b/bin/checkEventNtuple
@@ -24,7 +24,7 @@ def main():
                     h = f.Get("EventNtuple/version")
                     print("{} contains EventNtuple v{:02.0f}_{:02.0f}_{:02.0f}".format(filename, h.GetBinContent(1), h.GetBinContent(2), h.GetBinContent(3)))
                 else:
-                    print("{} histogram does not exist in {} (it is v06_02_00 or older)".format(histname, filename))
+                    print("{} histogram does not exist in {} (it is either v06_02_00 or older)".format(histname, filename))
             else:
                 print("{}/ folder does not exist in {}".format(foldername, filename))
         except OSError:

--- a/bin/checkEventNtuple
+++ b/bin/checkEventNtuple
@@ -1,0 +1,34 @@
+#!/bin/python3
+
+import argparse
+import ROOT
+
+# A main function so that this can be run on the command line
+def main():
+    parser = argparse.ArgumentParser(
+        prog='checkVersion',
+        description='Check the version of EventNtuple file',
+        epilog='For help, post to the #analysis-tools Slack channel')
+
+    parser.add_argument('filenames', nargs='*', help="Files to check")
+    args = parser.parse_args()
+
+    foldername = "EventNtuple"
+    histname = "version"
+    for filename in args.filenames:
+        try:
+            f = ROOT.TFile(filename, "READ");
+            if (f.GetListOfKeys().Contains(foldername)):
+                folder = f.Get(foldername)
+                if (folder.GetListOfKeys().Contains("version")):
+                    h = f.Get("EventNtuple/version")
+                    print("{} contains EventNtuple v{:0.0f}.{:0.0f}.{:0.0f}".format(filename, h.GetBinContent(1), h.GetBinContent(2), h.GetBinContent(3)))
+                else:
+                    print("{} histogram does not exist in {} (it is likely older than v6.3.0)".format(histname, filename))
+            else:
+                print("{}/ folder does not exist in {}".format(foldername, filename))
+        except OSError:
+            print("{} threw an OSError (does it exist?)".format(filename))
+
+if __name__ == "__main__":
+    main()

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -194,6 +194,7 @@ namespace mu2e {
 
       // main TTree
       TTree* _ntuple;
+      TH1I* _hVersion;
       // general event info branch
       EventInfo _einfo;
       EventInfoMC _einfomc;
@@ -393,6 +394,10 @@ namespace mu2e {
     art::ServiceHandle<art::TFileService> tfs;
     // create TTree
     _ntuple=tfs->make<TTree>("ntuple","Mu2e Event Ntuple");
+    _hVersion = tfs->make<TH1I>("version", "version number",3,0,3);
+    _hVersion->GetXaxis()->SetBinLabel(1, "major"); _hVersion->SetBinContent(1, 6);
+    _hVersion->GetXaxis()->SetBinLabel(2, "minor"); _hVersion->SetBinContent(2, 3);
+    _hVersion->GetXaxis()->SetBinLabel(3, "patch"); _hVersion->SetBinContent(3, 0);
     // add event info branch
     _ntuple->Branch("evtinfo",&_einfo,_buffsize,_splitlevel);
     if (_fillmc) {

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -171,7 +171,7 @@ namespace mu2e {
 
   void InfoMCStructHelper::fillAllSimInfos(const KalSeedMC& kseedmc, const PrimaryParticle& primary, std::vector<std::vector<SimInfo>>& all_siminfos, int n_generations, int n_match) {
     std::vector<SimInfo> siminfos;
-    
+
     // interpret -1 as no llimit
     if (n_generations == -1) {
       n_generations = std::numeric_limits<int>::max();
@@ -179,7 +179,7 @@ namespace mu2e {
     if (n_match == -1 ) {
       n_match = std::numeric_limits<int>::max();
     }
-    
+
     //create vector of art Ptr to particles:
     std::vector<art::Ptr<SimParticle> > allParts;
 
@@ -188,8 +188,8 @@ namespace mu2e {
       auto trkprimaryptr = kseedmc.simParticle(imatch).simParticle(_spcH);
       auto trkprimary = trkprimaryptr->originParticle();
       auto current_sim_particle_ptr = trkprimaryptr;
-      auto current_sim_particle = trkprimary; 
-      
+      auto current_sim_particle = trkprimary;
+
       for (int i_generation = 0; i_generation < n_generations; ++i_generation) {
         bool isSame = false;
         for(unsigned int ipart = 0; ipart < allParts.size() ; ipart++){
@@ -199,9 +199,8 @@ namespace mu2e {
             }
         }
         if(!isSame) { allParts.push_back(current_sim_particle_ptr); }
-      
+
         SimInfo sim_info;
-        
         fillSimInfo(current_sim_particle, sim_info);
         sim_info.trkrel = MCRelationship(current_sim_particle_ptr, trkprimaryptr);
         sim_info.rank = imatch;
@@ -223,7 +222,7 @@ namespace mu2e {
         }
         // record the index this object will have
         sim_info.index = siminfos.size();
-        
+
         if(!isSame) {
           siminfos.push_back(sim_info);
         }

--- a/utils/rooutil/inc/Event.hh
+++ b/utils/rooutil/inc/Event.hh
@@ -37,16 +37,31 @@
 struct Event {
   Event(TChain* ntuple) {
 
-    ntuple->SetBranchAddress("evtinfo", &this->evtinfo);
-    ntuple->SetBranchAddress("hitcount", &this->hitcount);
-    ntuple->SetBranchAddress("crvsummary", &this->crvsummary);
+    if (ntuple->GetBranch("evtinfo")) {
+      ntuple->SetBranchAddress("evtinfo", &this->evtinfo);
+    }
+    if (ntuple->GetBranch("hitcount")) {
+      ntuple->SetBranchAddress("hitcount", &this->hitcount);
+    }
+    if (ntuple->GetBranch("crvsummary")) {
+      ntuple->SetBranchAddress("crvsummary", &this->crvsummary);
+    }
 
-    ntuple->SetBranchAddress("trk", &this->trk);
-    ntuple->SetBranchAddress("trksegs", &this->trksegs);
-    ntuple->SetBranchAddress("trkcalohit", &this->trkcalohit);
-    ntuple->SetBranchAddress("trkqual", &this->trkqual);
-
-    ntuple->SetBranchAddress("crvcoincs", &this->crvcoincs);
+    if (ntuple->GetBranch("trk")) {
+      ntuple->SetBranchAddress("trk", &this->trk);
+    }
+    if (ntuple->GetBranch("trksegs")) {
+      ntuple->SetBranchAddress("trksegs", &this->trksegs);
+    }
+    if (ntuple->GetBranch("trkcalohit")) {
+      ntuple->SetBranchAddress("trkcalohit", &this->trkcalohit);
+    }
+    if (ntuple->GetBranch("trkqual")) {
+      ntuple->SetBranchAddress("trkqual", &this->trkqual);
+    }
+    if (ntuple->GetBranch("crvcoincs")) {
+      ntuple->SetBranchAddress("crvcoincs", &this->crvcoincs);
+    }
 
     // Check if the MC branches exist
     if (ntuple->GetBranch("evtinfomc")) {
@@ -91,6 +106,7 @@ struct Event {
 
 
     if (ntuple->GetBranch("trkmcsim")) {
+      std::cout << "AE: HERE" << std::endl;
       ntuple->SetBranchAddress("trkmcsim", &this->trkmcsim);
     }
     if (ntuple->GetBranch("trkhits")) {
@@ -105,39 +121,51 @@ struct Event {
   };
 
   void Update(bool debug = false) {
-    if (debug) { std::cout << "Event::pdate(): Clearing previous Tracks... " << std::endl; }
+    if (debug) { std::cout << "Event::Update(): Clearing previous Tracks... " << std::endl; }
     tracks.clear();
     for (int i_track = 0; i_track < nTracks(); ++i_track) {
       if (debug) { std::cout << "Event::Update(): Creating Track " << i_track << "... " << std::endl; }
       Track track(&(trk->at(i_track)), &(trksegs->at(i_track)), &(trkcalohit->at(i_track))); // passing the addresses of the underlying structs
       if (trkmc != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trkmc to Track " << i_track << "... " << std::endl; }
         track.trkmc = &(trkmc->at(i_track));
       }
       if (trksegsmc != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trksegsmc to Track " << i_track << "... " << std::endl; }
         track.trksegsmc = &(trksegsmc->at(i_track));
       }
       if (trksegpars_lh != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trksegpars_lh to Track " << i_track << "... " << std::endl; }
         track.trksegpars_lh = &(trksegpars_lh->at(i_track));
       }
       if (trksegpars_ch != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trksegpars_ch to Track " << i_track << "... " << std::endl; }
         track.trksegpars_ch = &(trksegpars_ch->at(i_track));
       }
       if (trksegpars_kl != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trksegpars_kl to Track " << i_track << "... " << std::endl; }
         track.trksegpars_kl = &(trksegpars_kl->at(i_track));
       }
       if (trkmcsim != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trkmcsim to Track " << i_track << "... (size = " << trkmcsim->at(i_track).size() << ")" << std::endl; }
         track.trkmcsim = &(trkmcsim->at(i_track));
       }
       if (trkhits != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trkhits to Track " << i_track << "... " << std::endl; }
         track.trkhits = &(trkhits->at(i_track));
       }
       if (trkhitsmc != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trkhitsmc to Track " << i_track << "... " << std::endl; }
         track.trkhitsmc = &(trkhitsmc->at(i_track));
       }
       if (trkmats != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trkmats to Track " << i_track << "... " << std::endl; }
         track.trkmats = &(trkmats->at(i_track));
       }
-      track.trkqual = &(trkqual->at(i_track));
+      if (trkqual != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Adding trkqual to Track " << i_track << "... " << std::endl; }
+        track.trkqual = &(trkqual->at(i_track));
+      }
 
       if (debug) { std::cout << "Event::Update(): Updating Track " << i_track << "... " << std::endl; }
       track.Update(debug);

--- a/utils/rooutil/inc/Event.hh
+++ b/utils/rooutil/inc/Event.hh
@@ -106,7 +106,6 @@ struct Event {
 
 
     if (ntuple->GetBranch("trkmcsim")) {
-      std::cout << "AE: HERE" << std::endl;
       ntuple->SetBranchAddress("trkmcsim", &this->trkmcsim);
     }
     if (ntuple->GetBranch("trkhits")) {

--- a/utils/rooutil/inc/RooUtil.hh
+++ b/utils/rooutil/inc/RooUtil.hh
@@ -5,6 +5,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
+#include "TH1I.h"
 
 #include "EventNtuple/utils/rooutil/inc/Event.hh"
 
@@ -17,14 +18,21 @@ public:
     std::string root_suffix = ".root";
     if (filename.compare(filename.size() - root_suffix.size(), root_suffix.size(), root_suffix) == 0) {
       ntuple->Add(filename.c_str());
+      SetVersionNumber(filename);
     }
     else { //  assume its a file list
       std::ifstream filelist(filename);
 
       if (filelist.is_open()) {
         std::string line;
+        bool first_line = true;
         while (std::getline(filelist, line)) {
           ntuple->Add(line.c_str());
+
+          if (first_line) {
+            SetVersionNumber(line);
+            first_line = false;
+          }
         }
         filelist.close();
       } else {
@@ -36,6 +44,22 @@ public:
   }
 
   void Debug(bool dbg) { debug = dbg; }
+
+  void SetVersionNumber(std::string filename) {
+    TFile* file = new TFile(filename.c_str(), "READ");
+    TH1I* hVersion = (TH1I*) file->Get("EventNtuple/version");
+    if (!hVersion) {
+      std::cout << "Warning: this EventNtuple file does not contain a version number. This is just a warning..." << std::endl;
+    }
+    else {
+      majorVer = hVersion->GetBinContent(1);
+      minorVer = hVersion->GetBinContent(2);
+      patchVer = hVersion->GetBinContent(3);
+      std::cout << "EventNtuple v" << majorVer << "." << minorVer << "." << patchVer << std::endl;
+    }
+    file->Close();
+    delete file;
+  }
 
   int GetNEvents() { return ntuple->GetEntries(); }
 
@@ -117,6 +141,10 @@ private:
   TChain* ntuple;
   Event* event; // holds all the variables for SetBranchAddress
   bool debug;
+
+  int majorVer;
+  int minorVer;
+  int patchVer;
 
   TTree* output_ntuple; // for output
 };

--- a/utils/rooutil/inc/RooUtil.hh
+++ b/utils/rooutil/inc/RooUtil.hh
@@ -49,13 +49,13 @@ public:
     TFile* file = new TFile(filename.c_str(), "READ");
     TH1I* hVersion = (TH1I*) file->Get("EventNtuple/version");
     if (!hVersion) {
-      std::cout << "Warning: this EventNtuple file does not contain a version number. This is just a warning..." << std::endl;
+      std::cout << "Warning: this EventNtuple file does not contain a version number. It is either v06_02_00 or older. This is just a warning..." << std::endl;
     }
     else {
       majorVer = hVersion->GetBinContent(1);
       minorVer = hVersion->GetBinContent(2);
       patchVer = hVersion->GetBinContent(3);
-      std::cout << "EventNtuple v" << majorVer << "." << minorVer << "." << patchVer << std::endl;
+      std::cout << "EventNtuple v" << std::setw(2) << std::setfill('0') << majorVer << "_" << minorVer << "_" << patchVer << std::endl;
     }
     file->Close();
     delete file;

--- a/utils/rooutil/inc/RooUtil.hh
+++ b/utils/rooutil/inc/RooUtil.hh
@@ -11,7 +11,7 @@
 
 class RooUtil {
 public:
-  RooUtil(std::string filename, std::string treename = "EventNtuple/ntuple") : debug(false) {
+  RooUtil(std::string filename, bool debug = false, std::string treename = "EventNtuple/ntuple") : debug(true) {
     ntuple = new TChain(treename.c_str());
 
     // Check if the given filename contains .root at the end

--- a/utils/rooutil/inc/Track.hh
+++ b/utils/rooutil/inc/Track.hh
@@ -25,6 +25,7 @@ struct Track {
     if (trksegsmc != nullptr) { // if we have MC information
       // search for corresponding SurfaceStepInfo (it will have the same sid and sindex)
       // also, trksegs and trksegms may not be the same length...
+      if (debug) { std::cout << "Track::Update(): Updating trksegsmc..." << std::endl; }
       for (size_t i_segment_mc = 0; i_segment_mc < trksegsmc->size(); ++i_segment_mc) {
         if (debug) { std::cout << "Track::Update(): Looking for trkseg to match trksegmc " << i_segment_mc << ".(of " << trksegsmc->size() << ").. "; }
         bool reco_step_found = false;
@@ -59,30 +60,36 @@ struct Track {
     }
 
     if (trkmcsim != nullptr) {
+      if (debug) { std::cout << "Track::Update(): Updating trkmcsim..." << std::endl; }
       // Create the underlying MCParticles if possible
       for (int i_mc_particle = 0; i_mc_particle < nMCParticles(); ++i_mc_particle) {
+        if (debug) { std::cout << "Track::Update(): Creating MCParticle " << i_mc_particle << " / " << nMCParticles() << "..." << std::endl; }
         MCParticle mc_particle(&(trkmcsim->at(i_mc_particle))); // passing the addresses of the underlying structs
         mc_particles.emplace_back(mc_particle);
       }
     }
 
     if (trksegpars_lh != nullptr) { // if we LoopHelix info
+      if (debug) { std::cout << "Track::Update(): Updating trksegpars_lh..." << std::endl; }
       for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
         segments[i_segment].trksegpars_lh = &(trksegpars_lh->at(i_segment));
       }
     }
     if (trksegpars_ch != nullptr) { // if we CentralHelix info
+      if (debug) { std::cout << "Track::Update(): Updating trksegpars_ch..." << std::endl; }
       for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
         segments[i_segment].trksegpars_ch = &(trksegpars_ch->at(i_segment));
       }
     }
     if (trksegpars_kl != nullptr) { // if we CentralHelix info
+      if (debug) { std::cout << "Track::Update(): Updating trksegpars_kl..." << std::endl; }
       for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
         segments[i_segment].trksegpars_kl = &(trksegpars_kl->at(i_segment));
       }
     }
 
     if (trkhits != nullptr) {
+      if (debug) { std::cout << "Track::Update(): Updating trkhits..." << std::endl; }
       // Create the underlying TrackHits
       for (int i_trkhit = 0; i_trkhit < nHits(); ++i_trkhit) {
         TrackHit trkhit;
@@ -95,6 +102,7 @@ struct Track {
         hits.emplace_back(trkhit);
       }
       if (trkhitsmc != nullptr) {
+        if (debug) { std::cout << "Track::Update(): Updating trkhitsmc..." << std::endl; }
         // Fill in the remainder of the track hits
         for (size_t i_trkhitmc = nHits(); i_trkhitmc < trkhitsmc->size(); ++i_trkhitmc) {
           TrackHit trkhit;


### PR DESCRIPTION
This PR adds a histogram to the output of EventNtuple that records the version number of EventNtuple. It also includes a command-line utility to check the version number ```checkEventNtuple```. RooUtil also records this version number. The README has also been updated with relevant information