### PR TITLE
Updates for calibration

### DIFF
--- a/fcl/from_mcs-DeCalib.fcl
+++ b/fcl/from_mcs-DeCalib.fcl
@@ -2,21 +2,24 @@
 # hit information in the branch
 #include "EventNtuple/fcl/from_mcs-mockdata.fcl"
 
-process_name: TADeM
+process_name: DeCalib
 source : { module_type : RootInput }
 services : @local::Services.Reco
 physics :
 {
   producers : {
     @table::EventNtuple.producers
+    DeMFilter : {
+    }
   }
-  TriggerPath : [ MergeKKDeMCalib ]
+  TriggerPath : [ MergeKKDeCalib ]
   analyzers : {
     EventNtuple : {
       @table::EventNtupleMaker
+      hasTracks : true
       FitType : LoopHelix
       branches :  [
-        { input: "MergeKKDeMCalib"
+        { input: "MergeKKDeCalib"
           branch : "trk"
           options : { fillMC : true fillHits : true  genealogyDepth : -1 }
         }
@@ -28,4 +31,4 @@ physics :
 physics.trigger_paths : [ TriggerPath ]
 physics.end_paths : [ EndPath ]
 services.TimeTracker.printSummary: true
-services.TFileService.fileName: "nts.owner.EventNtupleDeMCalib.version.sequence.root"
+services.TFileService.fileName: "nts.owner.EventNtupleDeCalib.version.sequence.root"

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -131,18 +131,18 @@ MergeKKDe           : @local::MergeKK
 MergeKKDe.KalSeedCollections : [ "KKDe" ]
 
 
-MergeKKDeMCalib : {
+MergeKKDeCalib : {
   @table::MergeKK
-  KalSeedCollections : ["KKDeM"]
+  KalSeedCollections : ["KKDe"]
   Selector : {
     tool_type : SimpleKalSeedSelector
-    MinMomentum : 70.0 # MeV/c
+    MinMomentum : 0.0 # MeV/c
     MaxMomentum : 300.0 #MeV/c
     MinFitConsistency : 1e-10
     MinDeltaNHitFraction : 0.05 # Consider a 5% difference in active hit count to be 'significant', and call the track more hits 'better'.  Otherwise, use fit quality to determine 'better'
     MinActiveHits : 15 # Require a reasonable # of active hits
   }
-  SelectBest : true # use only the 'best' DeM in every event
+  SelectBest : true # use only the 'best' De in every event
 }
 
 MergeKKProducers : {
@@ -157,8 +157,8 @@ MergeKKProducers : {
   MergeKKLine : @local::MergeKKLine
   MergeKKOff : @local::MergeKKOff
   MergeKKAll : @local::MergeKKAll
-  MergeKKDeMCalib : @local::MergeKKAll
   MergeKKDe : @local::MergeKKDe
+  MergeKKDeCalib : @local::MergeKKDeCalib
 }
 MergeKKProducersPath : [ MergeKKAll ]
 MergeKKNoFieldPath : [ MergeKKLine ]
@@ -211,7 +211,7 @@ All : { input : "MergeKKAll"
   options : { fillHits : true fillMC : true   genealogyDepth : -1 matchDepth : -1 }
   trkQualTag : "TrkQualAll"
 }
-DeMCalib : { input : "MergeKKDeMCalib"
+DeCalib : { input : "MergeKKDeCalib"
   branch : "trk"
   options : { fillMC : true fillHits : true  genealogyDepth : -1 matchDepth : -1 }
 }

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -132,7 +132,8 @@ namespace mu2e {
         fhicl::Atom<int> debug{Name("debugLevel"),0};
         fhicl::Atom<int> splitlevel{Name("splitlevel"),99};
         fhicl::Atom<int> buffsize{Name("buffsize"),32000};
-        // General event info
+        fhicl::Atom<bool> hastrks{Name("hasTracks"), Comment("Require >=1 tracks to fill tuple"), false};
+       // General event info
         fhicl::Atom<art::InputTag> rctag{Name("RecoCountTag"), Comment("RecoCount"), art::InputTag()};
         fhicl::Atom<art::InputTag> PBITag{Name("PBITag"), Comment("Tag for ProtonBunchIntensity object") ,art::InputTag()};
         fhicl::Atom<art::InputTag> PBTTag{Name("PBTTag"), Comment("Tag for ProtonBunchTime object") ,art::InputTag()};
@@ -191,13 +192,14 @@ namespace mu2e {
 
       Config _conf;
       std::vector<BranchConfig> _allBranches; // configurations for all track branches
-
       // main TTree
       TTree* _ntuple;
       // general event info branch
       EventInfo _einfo;
       EventInfoMC _einfomc;
       art::InputTag _recoCountTag, _PBITag, _PBTTag, _PBTMCTag;
+      // track control
+      bool _hastrks;
       // hit counting
       HitCount _hcnt;
       // track counting
@@ -313,8 +315,9 @@ namespace mu2e {
     _PBITag(conf().PBITag()),
     _PBTTag(conf().PBTTag()),
     _PBTMCTag(conf().PBTMCTag()),
+    _hastrks(conf().hastrks()),
     _fillmc(conf().fillmc()),
-    _fillcalomc(conf().fillCaloMC()),
+   _fillcalomc(conf().fillCaloMC()),
     // CRV
     _fillcrvcoincs(conf().fillcrvcoincs()),
     _fillcrvpulses(conf().fillcrvpulses()),
@@ -605,6 +608,7 @@ namespace mu2e {
     event.getByLabel(_surfaceStepsTag,_surfaceStepsHandle);
 
     // loop through all track types
+    unsigned ntrks(0);
     for (BranchIndex i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
       _allTIs.at(i_branch).clear();
       _allTSIs.at(i_branch).clear();
@@ -643,6 +647,7 @@ namespace mu2e {
           auto hptr = (*khassns)[i_kseedptr].second;
           _infoStructHelper.fillHelixInfo(hptr, _hinfos);
         }
+        ntrks++; // count total # of tracks
       }
     }
 
@@ -679,10 +684,8 @@ namespace mu2e {
       }
 
     }
-
-
     // fill this row in the TTree
-    _ntuple->Fill();
+    if((!_hastrks) || ntrks > 0) _ntuple->Fill();
   }
 
 


### PR DESCRIPTION
The new track lists put dem and dep together, so the calib output also has that. We could add filtering to select just dem, but for now I'm assuming that will be done in the analysis (cosmic events contain roughly even numbers of dem and dep fits (most dep are really muons).