### PR TITLE
Rename branch in EventNtuple from ceSimReco

### DIFF
--- a/fcl/from_mcs-ceSimReco.fcl
+++ b/fcl/from_mcs-ceSimReco.fcl
@@ -1,6 +1,7 @@
 #include "EventNtuple/fcl/from_mcs-mockdata.fcl"
 
 physics.analyzers.EventNtuple.branches : [ @local::De ]
+physics.analyzers.EventNtuple.branches[0].branch : "trk"
 physics.analyzers.EventNtuple.FillTriggerInfo : false
 physics.EventNtuplePath : [ MergeKKDe, PBIWeight, TrkQualDe, TrkPIDDe ]
 physics.EventNtupleEndPath : [ EventNtuple, genCountLogger ]


### PR DESCRIPTION
This had the old ```de``` name so I've changed it to ```trk``` so it can be analyzed with RooUtil