### PR TITLE
EventNtuple for CRV VST + Skip RecoCount and ProtonBunchTime data products

### DIFF
--- a/fcl/README.md
+++ b/fcl/README.md
@@ -24,3 +24,4 @@ where ```tier``` is the data tier of the input dataset, ```type``` is the type o
 | from_mcs-OffSpill.fcl | off spill datasets | only contains ```CentralHelix``` tracks (i.e. field-on cosmics) |
 | from_dig-mockdata.fcl | mock datasets (digis) | runs reconstruction and creates EventNtuple in one job |
 | from_dig-DeMCalib.fcl | digitized primary or mixed datasets | also runs reconstruction, only writes one track per event |
+| from_rec-crv-vst.fcl | CRV VST Data |  |

--- a/fcl/README.md
+++ b/fcl/README.md
@@ -24,4 +24,4 @@ where ```tier``` is the data tier of the input dataset, ```type``` is the type o
 | from_mcs-OffSpill.fcl | off spill datasets | only contains ```CentralHelix``` tracks (i.e. field-on cosmics) |
 | from_dig-mockdata.fcl | mock datasets (digis) | runs reconstruction and creates EventNtuple in one job |
 | from_dig-DeMCalib.fcl | digitized primary or mixed datasets | also runs reconstruction, only writes one track per event |
-| from_rec-crv-vst.fcl | CRV VST Data |  |
+| from_rec-crv-vst.fcl | CRV VST Data | only contains ```evtinfo``` and ```crv*``` branches |

--- a/fcl/from_rec-crv-vst.fcl
+++ b/fcl/from_rec-crv-vst.fcl
@@ -1,0 +1,11 @@
+#include "EventNtuple/fcl/from_mcs-mockdata_noMC.fcl"
+
+physics.analyzers.EventNtuple.FillCRVDigis : true
+physics.analyzers.EventNtuple.FillCRVPulses : true
+physics.analyzers.EventNtuple.branches : [ ] # no track branches
+physics.analyzers.EventNtuple.RecoCountTag : ""
+physics.analyzers.EventNtuple.PBTTag : ""
+
+physics.analyzers.EventNtuple.CrvDigisTag : "CrvDigi"
+physics.analyzers.EventNtuple.CrvCoincidencesTag: "CrvCoincidenceClusterFinder"
+physics.analyzers.EventNtuple.CrvRecoPulsesTag: "CrvRecoPulses"

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -700,15 +700,19 @@ namespace mu2e {
     _einfo.run = event.run();
     _einfo.subrun = event.subRun();
 
-    auto recoCountHandle = event.getValidHandle<mu2e::RecoCount>(_recoCountTag);
-    auto recoCount = *recoCountHandle;
-    _infoStructHelper.fillHitCount(recoCount, _hcnt);
+    if (_recoCountTag != "") {
+      auto recoCountHandle = event.getValidHandle<mu2e::RecoCount>(_recoCountTag);
+      auto recoCount = *recoCountHandle;
+      _infoStructHelper.fillHitCount(recoCount, _hcnt);
+    }
 
     // currently no reco nproton estimate TODO
-    auto PBThandle = event.getValidHandle<mu2e::ProtonBunchTime>(_PBTTag);
-    auto PBT = *PBThandle;
-    _einfo.pbtime = PBT.pbtime_;
-    _einfo.pbterr = PBT.pbterr_;
+    if (_PBTTag != "") {
+      auto PBThandle = event.getValidHandle<mu2e::ProtonBunchTime>(_PBTTag);
+      auto PBT = *PBThandle;
+      _einfo.pbtime = PBT.pbtime_;
+      _einfo.pbterr = PBT.pbterr_;
+    }
 
     if (_fillmc) {
       auto PBTMChandle = event.getValidHandle<mu2e::ProtonBunchTimeMC>(_PBTMCTag);

--- a/validation/test_fcls.sh
+++ b/validation/test_fcls.sh
@@ -11,8 +11,9 @@ primary_dataset="mcs.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3.art"
 mixed_dataset="mcs.mu2e.CeEndpointMix1BBTriggered.MDC2020am_best_v1_3.art"
 extracted_dataset="mcs.mu2e.CosmicCRYExtractedCatTriggered.MDC2020ae_best_v1_3.art"
 digi_dataset="dig.mu2e.ensembleMDS1gOnSpillTriggered.MDC2020aq_perfect_v1_3.art"
+crv_vst_dataset="rec.mu2e.CRV_wideband_cosmics.CRVWBA-000-000-000.art"
 
-all_datasets=( $mock_dataset $primary_dataset $mixed_dataset $extracted_dataset $digi_dataset )
+all_datasets=( $mock_dataset $primary_dataset $mixed_dataset $extracted_dataset $digi_dataset $crv_vst_dataset )
 
 if [ ! -d ../filelists ]; then
      echo "Making directory ../filelists/"
@@ -112,6 +113,14 @@ fi
 
 echo -n "creating validation file... "
 root -l -b -q validation/create_val_file_rooutil.C\(\"nts.ntuple.after.root\",\"val.ntuple.after.root\"\) >> ${log_file} 2>&1
+if [ $? == 0 ]; then
+    echo "OK"
+else
+    echo "FAIL"
+fi
+
+echo -n "from_rec-crv-vst.fcl... "
+mu2e -c fcl/from_rec-crv-vst.fcl -S ../filelists/${crv_vst_dataset}.list --TFileName nts.ntuple.crv-vst.root -n 100 >> ${log_file} 2>&1
 if [ $? == 0 ]; then
     echo "OK"
 else


### PR DESCRIPTION
This PR adds a fhicl file that creates an EventNtuple on the CRV VST data.

Since the CRV VST data does not contain the ```mu2e::RecoCount``` or ```mu2e::ProtonBunchTime``` data products, I added the ability to skip those ```event.get()``` calls in the art module. To use this in future, set an empty input tag (```""```) in the fhicl configuration. I ran the validation (including ```valCompare```) and these changes do not affect previously-existing fhicl files