### PR TITLE
RooUtil fixes for CRV-only EventNtuples

### DIFF
--- a/utils/rooutil/examples/CreateTrackNtuple.C
+++ b/utils/rooutil/examples/CreateTrackNtuple.C
@@ -36,7 +36,7 @@ void CreateTrackNtuple(std::string filename) {
       trk = *(track.trk); // we will fill this data into the tree
 
       // Get the track segments at the tracker entrance
-      const auto& trk_ent_segments = track.GetSegments(tracker_entrance);
+      auto trk_ent_segments = track.GetSegments([](TrackSegment& segment){ return tracker_entrance(segment) && has_reco_step(segment); });
 
       // Loop through the tracker entrance track segments
       for (const auto& segment : trk_ent_segments) {

--- a/utils/rooutil/examples/PlotCRVTotalPEs.C
+++ b/utils/rooutil/examples/PlotCRVTotalPEs.C
@@ -1,0 +1,29 @@
+//
+// An example of how to plot CRV information
+// This uses cut functions defined in common_cuts.hh
+//
+
+#include "EventNtuple/utils/rooutil/inc/RooUtil.hh"
+#include "EventNtuple/utils/rooutil/inc/common_cuts.hh"
+
+#include "TH1F.h"
+
+void PlotCRVTotalPEs(std::string filename) {
+
+  // Create the histogram you want to fill
+  TH1F* hTotalPEs = new TH1F("hTotalPEs", "Total PEs from crvsummary", 100,0,200);
+
+  // Set up RooUtil
+  RooUtil util(filename);
+
+  // Loop through the events
+  for (int i_event = 0; i_event < util.GetNEvents(); ++i_event) {
+    // Get the next event
+    auto& event = util.GetEvent(i_event);
+
+    hTotalPEs->Fill(event.crvsummary->totalPEs);
+  }
+
+  // Draw the histogram
+  hTotalPEs->Draw("HIST E");
+}

--- a/utils/rooutil/inc/Event.hh
+++ b/utils/rooutil/inc/Event.hh
@@ -183,8 +183,14 @@ struct Event {
     }
   }
 
-  int nTracks() const { return trk->size(); }
-  int nCrvCoincs() const { return crvcoincs->size(); }
+  int nTracks() const {
+    if (trk == nullptr) { return 0; }
+    else { return trk->size(); }
+  }
+  int nCrvCoincs() const {
+    if (crvcoincs == nullptr) { return 0; }
+    else { return crvcoincs->size(); }
+  }
 
   Tracks GetTracks() { return tracks; }
   Tracks GetTracks(TrackCut cut, bool inplace = false) {

--- a/validation/test_rooutil_examples.sh
+++ b/validation/test_rooutil_examples.sh
@@ -1,12 +1,10 @@
-filename="\"../data/nts.mu2e.MDS1f.MDC2020ai_perfect_v1_3.root\""
+filename="\"/pnfs/mu2e/tape/phy-nts/nts/mu2e/CeEndpointOnSpillTriggered/MDC2020aq_best_v1_3_v06_03_00/root/ed/df/nts.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3_v06_03_00.001210_00000000.root\""
 
-root -l -b -q utils/rooutil/examples/PrintEvents.C++\(${filename},true\) # special script that takes an additional argument
-
-scripts=( "CreateNtuple.C" "CreateTrackNtuple.C" "PlotCRVPEs.C" "PlotCRVPEsVsMCEDep.C" "PlotEntranceFitPars.C" "PlotEntranceMomentum.C"
+scripts=( "PrintEvents.C" "CreateNtuple.C" "CreateTrackNtuple.C" "PlotCRVPEs.C" "PlotCRVPEsVsMCEDep.C" "PlotEntranceFitPars.C" "PlotEntranceMomentum.C"
           "PlotEntranceMomentumCRVCut.C" "PlotEntranceMomentumResolution.C" "PlotEntranceMomentumResolution_TrkQualCut.C"
           "PlotMCParentPosZ.C" "PlotMCParticleMom.C" "PlotMuonPosZ.C" "PlotStoppingTargetFoilSegment.C" "PlotTrackNHits_RecoVsTrue.C"
           "PlotTrkCaloHitEnergy.C" "PrintEventsNoMC.C" "TrackCounting.C" "PlotTrackHitTimes.C" "PlotTrackHitTimesMC.C" "PlotStrawMaterials.C"
-          "PlotGenCosmicMom.C" )
+          "PlotGenCosmicMom.C" "PlotCRVTotalPEs.C" )
 
 for script in "${scripts[@]}"
 do
@@ -20,4 +18,4 @@ done
 
 # Check the that reduced ntuple runs in RooUtil
 filename="\"example_ntuple.root\""
-root -l -b -q utils/rooutil/examples/PrintEvents.C++\(${filename},true\) # special script that takes an additional argument
+root -l -b -q utils/rooutil/examples/PrintEvents.C++\(${filename}\)


### PR DESCRIPTION
A couple of fixes needed so that RooUtil can run on the CRV-only EventNtuples