### PR TITLE
Add option to only write events when there is CRV data

### DIFF
--- a/fcl/from_rec-crv-vst.fcl
+++ b/fcl/from_rec-crv-vst.fcl
@@ -5,6 +5,7 @@ physics.analyzers.EventNtuple.FillCRVPulses : true
 physics.analyzers.EventNtuple.branches : [ ] # no track branches
 physics.analyzers.EventNtuple.RecoCountTag : ""
 physics.analyzers.EventNtuple.PBTTag : ""
+physics.analyzers.EventNtuple.hasCRV : true
 
 physics.analyzers.EventNtuple.CrvDigisTag : "CrvDigi"
 physics.analyzers.EventNtuple.CrvCoincidencesTag: "CrvCoincidenceClusterFinder"

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -133,6 +133,7 @@ namespace mu2e {
         fhicl::Atom<int> splitlevel{Name("splitlevel"),99};
         fhicl::Atom<int> buffsize{Name("buffsize"),32000};
         fhicl::Atom<bool> hastrks{Name("hasTracks"), Comment("Require >=1 tracks to fill tuple"), false};
+        fhicl::Atom<bool> hascrv{Name("hasCRV"), Comment("Require CRV information to fill tuple"), false};
        // General event info
         fhicl::Atom<art::InputTag> rctag{Name("RecoCountTag"), Comment("RecoCount"), art::InputTag()};
         fhicl::Atom<art::InputTag> PBITag{Name("PBITag"), Comment("Tag for ProtonBunchIntensity object") ,art::InputTag()};
@@ -201,6 +202,7 @@ namespace mu2e {
       art::InputTag _recoCountTag, _PBITag, _PBTTag, _PBTMCTag;
       // track control
       bool _hastrks;
+      bool _hascrv;
       // hit counting
       HitCount _hcnt;
       // track counting
@@ -317,6 +319,7 @@ namespace mu2e {
     _PBTTag(conf().PBTTag()),
     _PBTMCTag(conf().PBTMCTag()),
     _hastrks(conf().hastrks()),
+    _hascrv(conf().hascrv()),
     _fillmc(conf().fillmc()),
    _fillcalomc(conf().fillCaloMC()),
     // CRV
@@ -690,7 +693,16 @@ namespace mu2e {
 
     }
     // fill this row in the TTree
-    if((!_hastrks) || ntrks > 0) _ntuple->Fill();
+    bool fill = true; // default to fliling event
+    if(_hastrks && ntrks == 0) { // if we require tracks (_hastrks) but we have none, don't write
+      fill = false;
+    }
+    if (_hascrv && _crvsummary.totalPEs == 0) { // if we require CRV but we have none, don't write
+      fill = false;
+    }
+    if (fill) {
+      _ntuple->Fill();
+    }
   }
 
 

--- a/validation/test_fcls.sh
+++ b/validation/test_fcls.sh
@@ -126,3 +126,11 @@ if [ $? == 0 ]; then
 else
     echo "FAIL"
 fi
+
+echo -n "from_mcs-DeCalib.fcl... "
+mu2e -c fcl/from_mcs-DeCalib.fcl -S ../filelists/${mixed_dataset}.list --TFileName nts.ntuple.deCalib.root -n 100 >> ${log_file} 2>&1
+if [ $? == 0 ]; then
+    echo "OK"
+else
+    echo "FAIL"
+fi


### PR DESCRIPTION
This is for the CRV VST data and also shows the way forward for issue #256 . I've also added the fhicl file that exercises the equivalent option for the tracker. Validation passes