### PR TITLE
Add downstream and upstream track cuts to RooUtil

### DIFF
--- a/utils/rooutil/examples/PlotEntranceMomentum_UpstreamDownstream.C
+++ b/utils/rooutil/examples/PlotEntranceMomentum_UpstreamDownstream.C
@@ -1,0 +1,62 @@
+//
+// An example of how to plot the momentum of electrons at the tracker entrance
+// This uses cut functions defined in common_cuts.hh
+//
+
+#include "EventNtuple/utils/rooutil/inc/RooUtil.hh"
+#include "EventNtuple/utils/rooutil/inc/common_cuts.hh"
+
+#include "TH1F.h"
+
+void PlotEntranceMomentum_UpstreamDownstream(std::string filename) {
+
+  // Create the histogram you want to fill
+  TH1F* hRecoMomDown = new TH1F("hRecoMomDown", "Reconstructed Momentum at Tracker Entrance (downstream)", 50,95,110);
+  TH1F* hRecoMomUp = new TH1F("hRecoMomUp", "Reconstructed Momentum at Tracker Entrance (upstream)", 50,95,110);
+
+  // Set up RooUtil
+  RooUtil util(filename);
+
+  // Loop through the events
+  for (int i_event = 0; i_event < util.GetNEvents(); ++i_event) {
+    // Get the next event
+    auto& event = util.GetEvent(i_event);
+
+    // Get the downstream e_minus tracks from the event
+    auto dwn_e_minus_tracks = event.GetTracks([](Track& track){ return is_e_minus(track) && is_downstream(track); });
+    auto up_e_minus_tracks = event.GetTracks([](Track& track){ return is_e_minus(track) && is_upstream(track); });
+
+    // Loop through the dwn_e_minus tracks
+    for (auto& track : dwn_e_minus_tracks) {
+
+      // Get the track segments at the tracker entrance
+      auto trk_ent_segments = track.GetSegments([](TrackSegment& segment){ return tracker_entrance(segment) && has_reco_step(segment); });
+
+      // Loop through the tracker entrance track segments
+      for (auto& segment : trk_ent_segments) {
+
+        // Fill the histogram
+        hRecoMomDown->Fill(segment.trkseg->mom.R());
+      }
+    }
+
+    // Loop through the up_e_minus tracks
+    for (auto& track : up_e_minus_tracks) {
+
+      // Get the track segments at the tracker entrance
+      auto trk_ent_segments = track.GetSegments([](TrackSegment& segment){ return tracker_entrance(segment) && has_reco_step(segment); });
+
+      // Loop through the tracker entrance track segments
+      for (auto& segment : trk_ent_segments) {
+
+        // Fill the histogram
+        hRecoMomUp->Fill(segment.trkseg->mom.R());
+      }
+    }
+  }
+
+  // Draw the histogram
+  hRecoMomDown->Draw("HIST E");
+  hRecoMomUp->SetLineColor(kRed);
+  hRecoMomUp->Draw("HIST E SAME");
+}

--- a/utils/rooutil/inc/common_cuts.hh
+++ b/utils/rooutil/inc/common_cuts.hh
@@ -38,7 +38,6 @@ bool is_upstream(TrackSegment& segment) { // track fit segment is going in -z di
   else { return false; }
 }
 
-
 //+ Track Segment Cuts - Locations
 bool tracker_entrance(TrackSegment& segment) { // track fit segment is at the tracker entrance
   if (segment.trkseg != nullptr) {
@@ -54,14 +53,14 @@ bool tracker_entrance(TrackSegment& segment) { // track fit segment is at the tr
 
 bool tracker_middle(TrackSegment& segment) {  // track fit segment is at the middle of the tracker
   if (segment.trkseg != nullptr) {
-    if (segment.trkseg->sid==mu2e::SurfaceIdDetail::TT_Mid) { return true; }
-    else { return false; }
+    if (segment.trkseg->sid==mu2e::SurfaceIdDetail::TT_Mid) { std::cout << "returning true1" << std::endl; return true; }
+    else { std::cout << "returning false1" << std::endl; return false; }
   }
   if (segment.trksegmc != nullptr) {
-    if (segment.trksegmc->sid==mu2e::SurfaceIdDetail::TT_Mid) { return true; }
-    else { return false; }
+    if (segment.trksegmc->sid==mu2e::SurfaceIdDetail::TT_Mid) { std::cout << "returning true2" << std::endl; return true; }
+    else { std::cout << "returning false2" << std::endl; return false; }
   }
-  else { return false; }
+  else { std::cout << "returning false3" << std::endl; return false; }
 }
 
 bool tracker_exit(TrackSegment& segment) { // track fit segment is at the tracker exit
@@ -111,6 +110,30 @@ bool has_reco_step(TrackSegment& segment) { // track fit segment has an reco Sur
   else { return false; }
 }
 
+//+ Track Cuts - Direction
+bool is_downstream(Track& track) { // reconstructed fit segment at tracker middle is going in +z direction
+  auto tracker_middle_segments = track.GetSegments([](TrackSegment& segment){ return tracker_middle(segment) && !has_mc_step(segment) && has_reco_step(segment); });
+  if (tracker_middle_segments.size() > 1) {
+    std::cout << "WARNING: " << tracker_middle_segments.size() << " track segments at tracker middle. Something might have gone wrong..." << std::endl;
+    return false;
+  }
+  else if (tracker_middle_segments.size() == 0) {
+    return false;
+  }
+  return is_downstream(tracker_middle_segments.at(0));
+}
+
+bool is_upstream(Track& track) { // reconstructed fit segment at tracker middle is going in -z direction
+  auto tracker_middle_segments = track.GetSegments([](TrackSegment& segment){ return tracker_middle(segment) && !has_mc_step(segment) && has_reco_step(segment); });
+  if (tracker_middle_segments.size() > 1) {
+    std::cout << "WARNING: " << tracker_middle_segments.size() << " track segments at tracker middle. Something might have gone wrong..." << std::endl;
+    return false;
+  }
+  else if (tracker_middle_segments.size() == 0) {
+    return false;
+  }
+  return is_upstream(tracker_middle_segments.at(0));
+}
 
 //+ Track Cuts - Particle Types
 bool is_particle(Track& track, mu2e::PDGCode::type particle) { // track fit used particle hypothesis

--- a/validation/test_rooutil_examples.sh
+++ b/validation/test_rooutil_examples.sh
@@ -4,7 +4,7 @@ scripts=( "PrintEvents.C" "CreateNtuple.C" "CreateTrackNtuple.C" "PlotCRVPEs.C" 
           "PlotEntranceMomentumCRVCut.C" "PlotEntranceMomentumResolution.C" "PlotEntranceMomentumResolution_TrkQualCut.C"
           "PlotMCParentPosZ.C" "PlotMCParticleMom.C" "PlotMuonPosZ.C" "PlotStoppingTargetFoilSegment.C" "PlotTrackNHits_RecoVsTrue.C"
           "PlotTrkCaloHitEnergy.C" "PrintEventsNoMC.C" "TrackCounting.C" "PlotTrackHitTimes.C" "PlotTrackHitTimesMC.C" "PlotStrawMaterials.C"
-          "PlotGenCosmicMom.C" "PlotCRVTotalPEs.C" )
+          "PlotGenCosmicMom.C" "PlotCRVTotalPEs.C" "PlotEntranceMomentum_UpstreamDownstream.C" )
 
 for script in "${scripts[@]}"
 do


### PR DESCRIPTION
I've added cut functions for selecting downstream and upstream tracks to the RooUtil common_cuts.hh file. I've also added an example script to the examples directory