### PR TITLE
V06_05_00: Final Updates

### DIFF
--- a/fcl/from_dig-mockdata.fcl
+++ b/fcl/from_dig-mockdata.fcl
@@ -1,7 +1,7 @@
 #include "Offline/fcl/minimalMessageService.fcl"
 #include "Offline/fcl/standardProducers.fcl"
 #include "Offline/fcl/standardServices.fcl"
-#include "Production/JobConfig/reco/prolog.fcl"
+#include "Production/JobConfig/recoMC/prolog.fcl"
 #include "EventNtuple/fcl/prolog.fcl"
 
 process_name : EventNtuple
@@ -33,7 +33,7 @@ outputs : {
 }
 
 physics.EventNtuplePath : [
-  @sequence::Reconstruction.OnSpillMCPath,
+  @sequence::Reconstruction.OnSpillPath,
   @sequence::EventNtuple.Path
 ]
 physics.EventNtupleEndPath : [ @sequence::EventNtuple.EndPathNoMC ]
@@ -43,7 +43,7 @@ physics.trigger_paths : [ EventNtuplePath ]
 physics.end_paths : [ EventNtupleEndPath ]
 
 #include "Production/JobConfig/common/epilog.fcl"
-#include "Production/JobConfig/reco/epilog.fcl"
+#include "Production/JobConfig/recoMC/epilog.fcl"
 
 outputs.Output.fileName: "mcs.owner.description.version.sequencer.art"
 services.TFileService.fileName: "nts.owner.description.version.sequencer.root"

--- a/inc/CrvInfoHelper.hh
+++ b/inc/CrvInfoHelper.hh
@@ -39,7 +39,7 @@ namespace mu2e
           CrvHitInfoRecoCollection &recoInfo, CrvHitInfoMCCollection &MCInfo,
           CrvSummaryReco &recoSummary, CrvSummaryMC &MCSummary,
           CrvPlaneInfoMCCollection &MCInfoPlane, double crvPlaneY,
-          const PrimaryParticle& primary);
+          art::Handle<PrimaryParticle> const& primary);
 
       void FillCrvPulseInfoCollections(
           art::Handle<CrvRecoPulseCollection> const& crvRecoPulses,

--- a/src/CrvInfoHelper.cc
+++ b/src/CrvInfoHelper.cc
@@ -30,7 +30,7 @@ namespace mu2e
       CrvHitInfoRecoCollection &recoInfo, CrvHitInfoMCCollection &MCInfo,
       CrvSummaryReco &recoSummary, CrvSummaryMC &MCSummary,
       CrvPlaneInfoMCCollection &MCInfoPlane, double crvPlaneY,
-      const PrimaryParticle& primary) {
+      art::Handle<PrimaryParticle> const& primary) {
     GeomHandle<CosmicRayShield> CRS;
     GeomHandle<DetectorSystem> tdet;
 
@@ -160,7 +160,7 @@ namespace mu2e
     //locate points where the cosmic MC trajectories cross the xz plane of CRV-T
     if(mcTrajectories.isValid())
     {
-      auto bestprimarysp = primary.primarySimParticles().front();
+      auto bestprimarysp = primary->primarySimParticles().front();
       for(auto trajectoryIter=mcTrajectories->begin(); trajectoryIter!=mcTrajectories->end(); trajectoryIter++)
       {
         const art::Ptr<SimParticle> &trajectorySimParticle = trajectoryIter->first;

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -403,7 +403,7 @@ namespace mu2e {
     _ntuple=tfs->make<TTree>("ntuple","Mu2e Event Ntuple");
     _hVersion = tfs->make<TH1I>("version", "version number",3,0,3);
     _hVersion->GetXaxis()->SetBinLabel(1, "major"); _hVersion->SetBinContent(1, 6);
-    _hVersion->GetXaxis()->SetBinLabel(2, "minor"); _hVersion->SetBinContent(2, 4);
+    _hVersion->GetXaxis()->SetBinLabel(2, "minor"); _hVersion->SetBinContent(2, 5);
     _hVersion->GetXaxis()->SetBinLabel(3, "patch"); _hVersion->SetBinContent(3, 0);
     // add event info branch
     _ntuple->Branch("evtinfo",&_einfo,_buffsize,_splitlevel);

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -682,7 +682,7 @@ namespace mu2e {
       _crvHelper.FillCrvHitInfoCollections(
                                            _crvCoincidences, _crvCoincidenceMCs,
                                            _crvRecoPulses, _crvSteps, _mcTrajectories,_crvcoincs, _crvcoincsmc,
-                                           _crvsummary, _crvsummarymc, _crvcoincsmcplane, _crvPlaneY, *_pph);
+                                           _crvsummary, _crvsummarymc, _crvcoincsmcplane, _crvPlaneY, _pph);
       if(_fillcrvpulses){
         _crvHelper.FillCrvPulseInfoCollections(_crvRecoPulses, _crvDigiMCs,
                                               _crvpulses, _crvpulsesmc);

--- a/validation/test_fcls.sh
+++ b/validation/test_fcls.sh
@@ -6,11 +6,11 @@
 log_file="test_fcls.log"
 rm ${log_file}
 
-mock_dataset="mcs.mu2e.ensembleMDS1gOnSpillTriggered.MDC2020aq_perfect_v1_3.art"
-primary_dataset="mcs.mu2e.CeEndpointOnSpillTriggered.MDC2020aq_best_v1_3.art"
-mixed_dataset="mcs.mu2e.CeEndpointMix1BBTriggered.MDC2020am_best_v1_3.art"
-extracted_dataset="mcs.mu2e.CosmicCRYExtractedCatTriggered.MDC2020ae_best_v1_3.art"
-digi_dataset="dig.mu2e.ensembleMDS1gOnSpillTriggered.MDC2020aq_perfect_v1_3.art"
+mock_dataset="mcs.mu2e.DIOtail95OnSpillTriggered.MDC2020aw_best_v1_3.art" # TODO: revert back to mock data when ready
+primary_dataset="mcs.mu2e.CeEndpointOnSpillTriggered.MDC2020aw_best_v1_3.art"
+mixed_dataset="mcs.mu2e.CeEndpointMix1BBTriggered.MDC2020aw_best_v1_3.art"
+extracted_dataset="mcs.mu2e.CosmicCRYExtractedTriggered.MDC2020aw.art"
+digi_dataset="dig.mu2e.DIOtail95OnSpillTriggered.MDC2020au_perfect_v1_3.art"
 crv_vst_dataset="rec.mu2e.CRV_wideband_cosmics.CRVWBA-000-000-000.art"
 
 all_datasets=( $mock_dataset $primary_dataset $mixed_dataset $extracted_dataset $digi_dataset $crv_vst_dataset )


### PR DESCRIPTION
The final changes needed before tagging v06_05_00

I updated the validation script to run on up-to-date datasets:
* one note: there are no updated mock datasets (we are about to release a new version) so for this validation round I used DIOtail95 as a substitute

After going through validation, I fixed the following:
* bug in recent change to CrvInfoHelper that occurs when running over CRV VST data
* fhicl config changes to from_dig-mockdata.fcl

There is one fcl file that fails validation (```from_mcs-extracted.fcl```), which is due to a known issue (missing ProtonBunchTimMC), which Yuri and I already solved for another dataset