### PR TITLE
Fix ntuplehelper bug related to wildcards

### DIFF
--- a/helper/ntuplehelper.py
+++ b/helper/ntuplehelper.py
@@ -289,7 +289,7 @@ class nthelper:
                         # Check whether this row is an explanation for a leaf that we are asking for
                         for i_leaf in leaves:
                             if i_leaf == "*":
-                                if (row.find(" = ") != -1) and (row.find(";") != -1) and (row.find("//") != -1):
+                                if (row.find(";") != -1) and (row.find("//") != -1):
                                     if i_leaf not in leaf_explanations: # we want to only take the first occurance
                                         leaf_explanations[i_leaf] = "\n"+row
                                     else:

--- a/validation/ntuplehelper-test.py
+++ b/validation/ntuplehelper-test.py
@@ -12,7 +12,7 @@ nthelp.whatis(['evtinfo.run', 'evtinfo.subrun', 'evtinfo.event']) # should only 
 
 print("Testing wildcard")
 print("=========")
-nthelp.whatis(["trk.*", "trksegs.*"])
+nthelp.whatis(["trk.*", "trksegs.*", "caloclusters.*"])
 
 print("Testing a few errors")
 print("=========")


### PR DESCRIPTION
This PR fixes a bug in ntuplehelper where some variables were missing from the output when the wildcard was used (```ntuplehelper branchname.*```).

This was because I had been assuming that default values were being set like:
```
type variable = value;
```
in the info struct files when searching for lines to print. However, this is not always the case.