### PR TITLE
Update from_digi script

### DIFF
--- a/fcl/from_dig-DeCalib.fcl
+++ b/fcl/from_dig-DeCalib.fcl
@@ -46,12 +46,12 @@ physics :
 physics.end_paths : [ EndPath ]
 physics.trigger_paths : [ RecoPath ]
 
-physics.producers.TrkQualDeM.KalSeedPtrCollection : "MergeKKDeMCalib"
+physics.producers.TrkQualDeM.KalSeedPtrCollection : "MergeKKDeCalib"
 # Override provenance of some objects since this job doesn't run CompressRecoMCs
 physics.producers.CaloHitTruthMatch.primaryParticle : "compressDigiMCs"
 physics.producers.CaloHitTruthMatch.caloShowerSimCollection : "compressDigiMCs"
-# restrict reco to just DeM
-physics.producers.SelectReco.KalSeedCollections  : ["KKDeM"]
+# restrict reco to just De
+physics.producers.SelectReco.KalSeedCollections  : ["KKDe"]
 physics.producers.KKDeM.ModuleSettings.HelixSeedCollections : [ "MHDe" ]
 physics.producers.KKDeM.ModuleSettings.ComboHitCollection : "makeSH"
 physics.producers.KKDeM.ModuleSettings.CaloClusterCollection : "CaloClusterMaker"

--- a/fcl/from_dig-DeMCalib.fcl
+++ b/fcl/from_dig-DeMCalib.fcl
@@ -15,19 +15,14 @@ physics :
   producers : {
     @table::Reconstruction.producers
     @table::EventNtuple.producers
-    MakeSS : @local::CommonMC.MakeSSDigi
   }
   RecoPath : [
     @sequence::Reconstruction.CaloReco,
-    @sequence::Reconstruction.TrkReco,
+    @sequence::Reconstruction.TrkHitReco,
+    @sequence::Reconstruction.DeReco,
     @sequence::Reconstruction.CrvReco,
-    TimeClusterFinderDe, HelixFinderDe,
-    CalTimePeakFinder, CalHelixFinderDe,
-    CalTimePeakFinderMu, CalHelixFinderDmu,
-    MHDeM,
-    KKDeM,
-    MergeKKDeMCalib,
-    MakeSS,
+    MergeKKDeCalib,
+    TrkQualDeM,
     @sequence::Reconstruction.MCReco
   ]
   analyzers : {
@@ -35,8 +30,9 @@ physics :
       @table::EventNtupleMaker
       FitType : LoopHelix
       branches :  [
-        { input: "MergeKKDeMCalib"
+        { input: "MergeKKDeCalib"
           branch : "trk"
+          trkQualTag : "TrkQualDeM"
           options : { fillMC : true fillHits : true  genealogyDepth : -1 }
         }
       ]
@@ -46,19 +42,21 @@ physics :
 }
 #include "Production/JobConfig/reco/epilog.fcl"
 #include "Production/Validation/database.fcl"
+#
+physics.end_paths : [ EndPath ]
+physics.trigger_paths : [ RecoPath ]
+
+physics.producers.TrkQualDeM.KalSeedPtrCollection : "MergeKKDeMCalib"
 # Override provenance of some objects since this job doesn't run CompressRecoMCs
 physics.producers.CaloHitTruthMatch.primaryParticle : "compressDigiMCs"
 physics.producers.CaloHitTruthMatch.caloShowerSimCollection : "compressDigiMCs"
 # restrict reco to just DeM
 physics.producers.SelectReco.KalSeedCollections  : ["KKDeM"]
-physics.producers.SelectReco.HelixSeedCollections  : ["MHDeM"]
-physics.producers.KKDeM.ModuleSettings.HelixSeedCollections : [ "MHDeM" ]
+physics.producers.KKDeM.ModuleSettings.HelixSeedCollections : [ "MHDe" ]
 physics.producers.KKDeM.ModuleSettings.ComboHitCollection : "makeSH"
 physics.producers.KKDeM.ModuleSettings.CaloClusterCollection : "CaloClusterMaker"
-physics.producers.compressRecoMCs.surfaceStepTags: [ "MakeSS" ]
-# turn off unnecessary extrapolation
-physics.producers.KKDeM.Extrapolation.Upstream : false
-physics.producers.KKDeM.Extrapolation.ToOPA : false
-physics.end_paths : [ EndPath ]
+# extrapolation
+physics.producers.KKDeM.Extrapolation.Upstream : true
+physics.producers.KKDeM.Extrapolation.ToOPA : true
 services.TimeTracker.printSummary: true
-services.TFileService.fileName: "nts.owner.EventNtupleDeMCalib.version.sequence.root"
+services.TFileService.fileName: "nts.owner.EventNtupleDeCalib.version.sequence.root"

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -70,7 +70,7 @@ namespace mu2e {
       void fillHitInfoMC(const KalSeedMC& kseedmc, TrkStrawHitInfoMC& tshinfomc, const TrkStrawHitMC& tshmc);
       void fillAllSimInfos(const KalSeedMC& kseedmc, const PrimaryParticle& primary, std::vector<std::vector<SimInfo>>& all_siminfos, int n_generations, int n_match);
       void fillVDInfo(KalSeed const& kseed, const KalSeedMC& kseedmc, std::vector<std::vector<MCStepInfo>>& all_vdinfos);
-      void fillHitInfoMCs(const KalSeedMC& kseedmc, std::vector<std::vector<TrkStrawHitInfoMC>>& all_tshinfomcs);
+      void fillHitInfoMCs(const KalSeed& kseed, const KalSeedMC& kseedmc, std::vector<std::vector<TrkStrawHitInfoMC>>& all_tshinfomcs);
       void fillCaloClusterInfoMC(CaloClusterMC const& ccmc, std::vector<CaloClusterInfoMC>& ccimc);
       void fillExtraMCStepInfos(KalSeedMC const& kseedmc, StepPointMCCollection const& mcsteps,
                                 std::vector<MCStepInfos>& mcsics, std::vector<MCStepSummaryInfo>& mcssis);

--- a/inc/TrkSegInfo.hh
+++ b/inc/TrkSegInfo.hh
@@ -19,8 +19,6 @@ namespace mu2e
     float momerr = -1000;  // projected error on the scalar momentum
     bool inbounds = false; // was the intersection within the (literal) surface bounds?
     bool gap = false; // was the intersection in a piecewise trajectory gap?
-    bool early = false; // is this the earliest intersection for this track?
-    bool late = false; // is this the latest intersection for this track?
     int sid = SurfaceIdEnum::unknown; // SurfaceId of the intersected surface, see Offline/KinKalGeom/inc/SurfaceId.hh for definitions
     int sindex = 0; // index to the intersected surface (for multi-surface elements like StoppingTarget)
     void reset() { *this = TrkSegInfo(); }

--- a/inc/TrkStrawHitInfoMC.hh
+++ b/inc/TrkStrawHitInfoMC.hh
@@ -31,6 +31,7 @@ namespace mu2e
     float strawdoca = -1000.0; // true transverse distance at POCA of the particle to the straw center
     float strawphi = -1000.0; // cylindrical phi around straw center of POCA
     XYZVectorF cpos; // threshold cluster position
+    bool recohit = true; // Is this MC info associated with a reco hit or not
   };
 }
 #endif

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -739,13 +739,13 @@ namespace mu2e {
 
                 if (_fillcalodigis){
                   const auto& digi = recodigi->caloDigiPtr();
-          
+
                   int digi_idx = _caloDIs.size();
                   _infoStructHelper.fillCaloDigiInfo(*digi,_caloDIs,recodigi_idx);
-    
+
                   //Update the recodigi
                   _caloRDIs.back().caloDigiIdx_ = digi_idx;
-    
+
                 }
               }
             }
@@ -773,13 +773,13 @@ namespace mu2e {
 
               if (_fillcalodigis){
                 const auto& digi = recodigi->caloDigiPtr();
-        
+
                 int digi_idx = _caloDIs.size();
                 _infoStructHelper.fillCaloDigiInfo(*digi,_caloDIs,recodigi_idx);
-  
+
                 //Update the recodigi
                 _caloRDIs.back().caloDigiIdx_ = digi_idx;
-  
+
               }
             }
           }
@@ -1011,7 +1011,7 @@ namespace mu2e {
           _infoMCStructHelper.fillAllSimInfos(kseedmc, primary, _allMCSimTIs.at(i_branch), branchConfig.options().genealogyDepth(), branchConfig.options().matchDepth());
 
           if(_conf.diag() > 1 || (_conf.fillhits() && branchConfig.options().fillhits())){
-            _infoMCStructHelper.fillHitInfoMCs(kseedmc, _allTSHIMCs.at(i_branch));
+            _infoMCStructHelper.fillHitInfoMCs(kseed,kseedmc, _allTSHIMCs.at(i_branch));
           }
           // fill extra MCStep info for this branch
           for(size_t ixt = 0; ixt < _extraMCStepTags.size(); ixt++){

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -116,22 +116,10 @@ namespace mu2e {
 
   void InfoStructHelper::fillTrkSegInfo(const KalSeed& kseed, std::vector<std::vector<TrkSegInfo>>& all_tsis) {
     std::vector<TrkSegInfo> tsis;
-    double tmin(std::numeric_limits<float>::max());
-    double tmax(std::numeric_limits<float>::lowest());
-    size_t imin(0), imax(0);
     for(size_t ikinter = 0; ikinter < kseed.intersections().size(); ++ikinter){
       auto const& kinter = kseed.intersections()[ikinter];
-      // record earliest and latest intersections
-      if(kinter.time() < tmin){
-        tmin = kinter.time();
-        imin = ikinter;
-      }
-      if(kinter.time() > tmax){
-        tmax = kinter.time();
-        imax = ikinter;
-      }
       TrkSegInfo tsi;
-      tsi.mom = kinter.momentum3();
+      tsi.mom = kinter.momentum3(); // momentum before traversing any material
       tsi.pos = kinter.position3();
       tsi.time = kinter.time();
       tsi.momerr = kinter.momerr();
@@ -141,11 +129,6 @@ namespace mu2e {
       tsi.sindex = kinter.surfid_.index();
       tsi.dmom = kinter.dMom();
       tsis.push_back(tsi);
-    }
-    // now flag early and latest intersections
-    if(tsis.size() > 0){
-      tsis[imin].early = true;
-      tsis[imax].late = true;
     }
     std::sort(tsis.begin(),tsis.end(),[](const auto& a, const auto& b){return a.time < b.time;});
     all_tsis.push_back(tsis);
@@ -176,7 +159,7 @@ namespace mu2e {
     }
     all_lhis.push_back(lhis);
   }
- 
+
   void InfoStructHelper::fillCentralHelixInfo(const KalSeed& kseed, std::vector<std::vector<CentralHelixInfo>>& all_chis) {
     std::vector<CentralHelixInfo> chis;
     for(auto const& kinter : kseed.intersections()) {
@@ -221,7 +204,7 @@ namespace mu2e {
     }
     all_klis.push_back(klis);
  }
- 
+
  void InfoStructHelper::fillTrkQualInfo(const KalSeed& kseed, MVAResult mva, std::vector<MVAResultInfo>& all_mvas) {
     MVAResultInfo temp_result;
     temp_result.result = mva._value;


### PR DESCRIPTION
This includes some minor improvements:
- use R() instead of sqrt(mag2()) for XYZVector payload.
-  removes the (non-functional) earliest and latest intersection flg, which can be extracted during analysis anyways.
- add a flag for trkstrawinfomc that are matched to trkstrawinfo. This isn't strictly necessary but can be helpful
-use combined KK reco sequence output in the from_digi script

I note that the rest of the config assumes the KKDeM, KKDeP split outputs, which is inconsistent with the head of Offline and the most recent MDC2020 samples. This might be a good time to reconsider having split trees. Some reworking of TrkQual calculation is also needed, which may impact how it is trained, or at least how the module loads the training.