### PR TITLE
Add new calo branches to RooUtil

### DIFF
--- a/rooutil/README.md
+++ b/rooutil/README.md
@@ -89,12 +89,21 @@ The ```CrvCoinc``` class contains paired reco and MC information about a single 
 
 Example: [PlotCRVPEsVsMCEDep.C](./examples/PlotCRVPEsVsMCEDep.C)
 
+
 ### ```MCParticle``` Class
 The ```MCParticle``` class contains information about a single SimParticle in the genealogy
 
 * single objects: ```mcsim```
 
 Example: [PlotMCParentPosZ.C](./examples/PlotMCParentPosZ.C)
+
+### The ```CaloCluster``` Class
+The ```CaloCluster``` class contains all information related to a single calorimeter cluster
+
+* single objects: ```calocluster```
+
+Example: [PlotCaloClusterEnergy.C](./examples/PlotCaloClusterEnergy.C)
+
 
 ### Branches not contained within a class
 Some branches are not contained in any of the above classes:
@@ -103,7 +112,7 @@ Some branches are not contained in any of the above classes:
 * ```crvdigis```
 * ```crvpulses``` and ```crvpulsesmc```
 * ```crvcoincsmcplane```
-* ```caloclusters```, ```calohits```, ```calorecodigis```, ```calodigis```
+* ```calohits```, ```calorecodigis```, ```calodigis```
 
 Reach out to the developers on the #analysis-tools Slack channel if you have a need to have these added somewhere.
 

--- a/rooutil/README.md
+++ b/rooutil/README.md
@@ -103,6 +103,7 @@ Some branches are not contained in any of the above classes:
 * ```crvdigis```
 * ```crvpulses``` and ```crvpulsesmc```
 * ```crvcoincsmcplane```
+* ```caloclusters```, ```calohits```, ```calorecodigis```, ```calodigis```
 
 Reach out to the developers on the #analysis-tools Slack channel if you have a need to have these added somewhere.
 

--- a/rooutil/examples/PlotCaloClusterEnergy.C
+++ b/rooutil/examples/PlotCaloClusterEnergy.C
@@ -1,0 +1,37 @@
+//
+// An example of how to plot reco vs true
+// This uses cut functions defined in common_cuts.hh
+//
+
+#include "EventNtuple/rooutil/inc/RooUtil.hh"
+#include "EventNtuple/rooutil/inc/common_cuts.hh"
+
+#include "TH1F.h"
+
+void PlotCaloClusterEnergy(std::string filename) {
+
+  // Create the histogram you want to fill
+  TH1F* hCaloClusterEnergy = new TH1F("hCaloClusterEnergy", "Energy (all clusters)", 110,0,110);
+  hCaloClusterEnergy->SetXTitle("Energy [MeV]");
+
+  // Set up RooUtil
+  RooUtil util(filename);
+
+  // Loop through the events
+  for (int i_event = 0; i_event < util.GetNEvents(); ++i_event) {
+    // Get the next event
+    auto& event = util.GetEvent(i_event);
+
+    // Get the e_minus tracks from the event
+    auto calo_clusters = event.GetCaloClusters();
+
+    // Loop through the e_minus tracks
+    for (auto& calo_cluster : calo_clusters) {
+      // Fill the histogram
+      hCaloClusterEnergy->Fill(calo_cluster.calocluster->energyDep_);
+    }
+  }
+
+  // Draw the histogram
+  hCaloClusterEnergy->Draw("HIST E");
+}

--- a/rooutil/examples/PrintEvents.C
+++ b/rooutil/examples/PrintEvents.C
@@ -211,5 +211,33 @@ void PrintEvents(std::string filename) {
         std::cout << "crvcoincmcplane: " << crvcoincmcplane.pdgId << "," << crvcoincmcplane.primary.z() << ", " << crvcoincmcplane.kineticEnergy << ", " << crvcoincmcplane.dataSource << std::endl;
       }
     }
+
+    // caloclusters branch
+    if (event.caloclusters != nullptr) {
+      for (const auto& calocluster : *(event.caloclusters)) {
+        std::cout << "calocluster: " << calocluster.diskID_ << ", " << calocluster.time_ << ", " << calocluster.timeErr_ << ", " << calocluster.energyDep_ << ", " << calocluster.energyDepErr_ << ", " << calocluster.isSplit_ << std::endl;
+      }
+    }
+
+    // calohits branch
+    if (event.calohits != nullptr) {
+      for (const auto& calohit : *(event.calohits)) {
+        std::cout << "calohit: " << calohit.crystalId_ << ", " << calohit.time_ << ", " << calohit.timeErr_ << ", " << calohit.eDep_ << ", " << calohit.eDepErr_ << ", " << calohit.clusterIdx_ << std::endl;
+      }
+    }
+
+    // calorecodigis branch
+    if (event.calorecodigis != nullptr) {
+      for (const auto& calorecodigi : *(event.calorecodigis)) {
+        std::cout << "calorecodigi: " << calorecodigi.time_ << ", " << calorecodigi.timeErr_ << ", " << calorecodigi.eDep_ << ", " << calorecodigi.eDepErr_ << ", " << calorecodigi.caloHitIdx_ << std::endl;
+      }
+    }
+
+    // calodigis branch
+    if (event.calodigis != nullptr) {
+      for (const auto& calodigi : *(event.calodigis)) {
+        std::cout << "calodigi: " << calodigi.SiPMID_ << ", " << calodigi.t0_ << ", " << calodigi.peakpos_ << ", " << calodigi.caloRecoDigiIdx_ << std::endl;
+      }
+    }
   }
 }

--- a/rooutil/inc/CaloCluster.hh
+++ b/rooutil/inc/CaloCluster.hh
@@ -1,0 +1,24 @@
+#ifndef CaloCluster_hh_
+#define CaloCluster_hh_
+
+#include <functional>
+#include "EventNtuple/inc/CaloClusterInfo.hh"
+#include "EventNtuple/inc/CaloHitInfo.hh"
+
+struct CaloCluster {
+  CaloCluster(mu2e::CaloClusterInfo* calocluster)
+    : calocluster(calocluster) {
+
+  }
+
+  void Update(bool debug = false) {
+  }
+
+  // Pointers to the data
+  mu2e::CaloClusterInfo* calocluster = nullptr;
+};
+
+typedef std::function<bool(CaloCluster&)> CaloClusterCut;
+typedef std::vector<CaloCluster> CaloClusters;
+
+#endif

--- a/rooutil/inc/Event.hh
+++ b/rooutil/inc/Event.hh
@@ -13,6 +13,11 @@
 #include "EventNtuple/inc/TrkCaloHitInfo.hh"
 #include "EventNtuple/inc/CaloClusterInfoMC.hh"
 
+#include "EventNtuple/inc/CaloClusterInfo.hh"
+#include "EventNtuple/inc/CaloHitInfo.hh"
+#include "EventNtuple/inc/CaloRecoDigiInfo.hh"
+#include "EventNtuple/inc/CaloDigiInfo.hh"
+
 #include "EventNtuple/inc/CrvHitInfoReco.hh"
 #include "EventNtuple/inc/CrvHitInfoMC.hh"
 #include "EventNtuple/inc/CrvWaveformInfo.hh"
@@ -117,6 +122,20 @@ struct Event {
     if (ntuple->GetBranch("trkmats")) {
       ntuple->SetBranchAddress("trkmats", &this->trkmats);
     }
+
+    if (ntuple->GetBranch("caloclusters")) {
+      ntuple->SetBranchAddress("caloclusters", &this->caloclusters);
+    }
+    if (ntuple->GetBranch("calohits")) {
+      ntuple->SetBranchAddress("calohits", &this->calohits);
+    }
+    if (ntuple->GetBranch("calorecodigis")) {
+      ntuple->SetBranchAddress("calorecodigis", &this->calorecodigis);
+    }
+    if (ntuple->GetBranch("calodigis")) {
+      ntuple->SetBranchAddress("calodigis", &this->calodigis);
+    }
+
   };
 
   void Update(bool debug = false) {
@@ -285,6 +304,11 @@ struct Event {
   std::vector<std::vector<mu2e::TrkStrawHitInfo>>* trkhits = nullptr;
   std::vector<std::vector<mu2e::TrkStrawHitInfoMC>>* trkhitsmc = nullptr;
   std::vector<std::vector<mu2e::TrkStrawMatInfo>>* trkmats = nullptr;
+
+  std::vector<mu2e::CaloClusterInfo>* caloclusters = nullptr;
+  std::vector<mu2e::CaloHitInfo>* calohits = nullptr;
+  std::vector<mu2e::CaloRecoDigiInfo>* calorecodigis = nullptr;
+  std::vector<mu2e::CaloDigiInfo>* calodigis = nullptr;
 
   std::vector<mu2e::CrvHitInfoReco>* crvcoincs = nullptr;
   std::vector<mu2e::CrvHitInfoMC>* crvcoincsmc = nullptr;

--- a/rooutil/inc/RooUtil.hh
+++ b/rooutil/inc/RooUtil.hh
@@ -124,6 +124,11 @@ public:
     if(event->trkhitsmc) { output_ntuple->Branch("trkhitsmc", event->trkhitsmc); }
     if(event->trkmats) { output_ntuple->Branch("trkmats", event->trkmats); }
 
+    if(event->caloclusters) { output_ntuple->Branch("caloclusters", event->caloclusters); }
+    if(event->calohits) { output_ntuple->Branch("calohits", event->calohits); }
+    if(event->calorecodigis) { output_ntuple->Branch("calorecodigis", event->calorecodigis); }
+    if(event->calodigis) { output_ntuple->Branch("calodigis", event->calodigis); }
+
     if(event->crvcoincs) { output_ntuple->Branch("crvcoincs", event->crvcoincs); }
     if(event->crvcoincsmc) { output_ntuple->Branch("crvcoincsmc", event->crvcoincsmc); }
     if(event->crvdigis) { output_ntuple->Branch("crvdigis", event->crvdigis); }

--- a/validation/create_val_file_rooutil.C
+++ b/validation/create_val_file_rooutil.C
@@ -426,6 +426,43 @@ void create_val_file_rooutil(std::string filename, std::string outfilename) {
   TH1F* h_crvcoicsmcplane_kineticEnergy = new TH1F("h_crvcoincsmcplane_kineticEnergy", "", 200,0,200);
   TH1F* h_crvcoicsmcplane_dataSource = new TH1F("h_crvcoincsmcplane_dataSource", "", 100,0,100);
 
+  TH1F* h_caloclusters_diskID_ = new TH1F("h_caloclusters_diskID_", "", 2,0,2);
+  TH1F* h_caloclusters_time_ = new TH1F("h_caloclusters_time_", "", 200,0,2000);
+  TH1F* h_caloclusters_timeErr_ = new TH1F("h_caloclusters_timeErr_", "", 100,0,100);
+  TH1F* h_caloclusters_energyDep_ = new TH1F("h_caloclusters_energyDep_", "", 100,0,100);
+  TH1F* h_caloclusters_energyDepErr_ = new TH1F("h_caloclusters_energyDepErr_", "", 100,0,100);
+  TH1F* h_caloclusters_cog_x = new TH1F("h_caloclusters_cog_x", "", 100,-500,500);
+  TH1F* h_caloclusters_cog_y = new TH1F("h_caloclusters_cog_y", "", 100,-500,500);
+  TH1F* h_caloclusters_cog_z = new TH1F("h_caloclusters_cog_z", "", 100,-500,500);
+  TH1F* h_caloclusters_hits_ = new TH1F("h_caloclusters_hits_", "", 100,0,100);
+  TH1F* h_caloclusters_size_ = new TH1F("h_caloclusters_size_", "", 100,0,100);
+  TH1F* h_caloclusters_isSplit_ = new TH1F("h_caloclusters_isSplit_", "", 2,0,2);
+
+  TH1F* h_calohits_crystalId_ = new TH1F("h_calohits_crystalId_", "", 2,0,2);
+  TH1F* h_calohits_nSiPMs_ = new TH1F("h_calohits_nSiPMs_", "", 100,0,100);
+  TH1F* h_calohits_time_ = new TH1F("h_calohits_time_", "", 200,0,2000);
+  TH1F* h_calohits_timeErr_ = new TH1F("h_calohits_timeErr_", "", 100,0,100);
+  TH1F* h_calohits_eDep_ = new TH1F("h_calohits_eDep_", "", 100,0,100);
+  TH1F* h_calohits_eDepErr_ = new TH1F("h_calohits_eDepErr_", "", 100,0,100);
+  TH1F* h_calohits_recoDigis_ = new TH1F("h_calohits_recoDigis_", "", 100,0,100);
+  TH1F* h_calohits_clusterIdx_ = new TH1F("h_calohits_clusterIdx_", "", 100,0,100);
+
+  TH1F* h_calorecodigis_eDep_ = new TH1F("h_calorecodigis_eDep_", "", 100,0,100);
+  TH1F* h_calorecodigis_eDepErr_ = new TH1F("h_calorecodigis_eDepErr_", "", 100,0,100);
+  TH1F* h_calorecodigis_time_ = new TH1F("h_calorecodigis_time_", "", 200,0,2000);
+  TH1F* h_calorecodigis_timeErr_ = new TH1F("h_calorecodigis_timeErr_", "", 100,0,100);
+  TH1F* h_calorecodigis_chi2_ = new TH1F("h_calorecodigis_chi2_", "", 100,0,100);
+  TH1F* h_calorecodigis_ndf_ = new TH1F("h_calorecodigis_ndf_", "", 100,0,100);
+  TH1F* h_calorecodigis_pileUp_ = new TH1F("h_calorecodigis_pileUp_", "", 2,0,2);
+  TH1F* h_calorecodigis_caloDigiIdx_ = new TH1F("h_calorecodigis_caloDigiIdx_", "", 100,0,100);
+  TH1F* h_calorecodigis_caloHitIdx_ = new TH1F("h_calorecodigis_caloHitIdx_", "", 100,0,100);
+
+  TH1F* h_calodigis_SiPMID_ = new TH1F("h_calodigis_SiPMID_", "", 100,0,100);
+  TH1F* h_calodigis_t0_ = new TH1F("h_calodigis_t0_", "", 100,0,100);
+  TH1F* h_calodigis_waveform_ = new TH1F("h_calodigis_waveform_", "", 100,0,100);
+  TH1F* h_calodigis_peakpos_ = new TH1F("h_calodigis_peakpos_", "", 100,0,100);
+  TH1F* h_calodigis_caloRecoDigiIdx_ = new TH1F("h_calodigis_caloRecoDigiIdx_", "", 100,0,100);
+
   for (int i_event = 0; i_event < util.GetNEvents(); ++i_event) {
     std::cout << "Event #" << i_event << std::endl;
     const auto& event = util.GetEvent(i_event);
@@ -949,8 +986,76 @@ void create_val_file_rooutil(std::string filename, std::string outfilename) {
         h_crvcoicsmcplane_dataSource->Fill(crvcoincmcplane.dataSource);
       }
     }
+
+
+    if (event.caloclusters != nullptr) {
+      std::cout << "Creating caloclusters histograms..." << std::endl;
+      for (const auto& calocluster : *(event.caloclusters)) {
+        h_caloclusters_diskID_->Fill(calocluster.diskID_);
+        h_caloclusters_time_->Fill(calocluster.time_);
+        h_caloclusters_timeErr_->Fill(calocluster.timeErr_);
+        h_caloclusters_energyDep_->Fill(calocluster.energyDep_);
+        h_caloclusters_energyDepErr_->Fill(calocluster.energyDepErr_);
+        h_caloclusters_cog_x->Fill(calocluster.cog_.x());
+        h_caloclusters_cog_y->Fill(calocluster.cog_.y());
+        h_caloclusters_cog_z->Fill(calocluster.cog_.z());
+        for (const auto& i_hit : calocluster.hits_) {
+          h_caloclusters_hits_->Fill(i_hit);
+        }
+        h_caloclusters_size_->Fill(calocluster.size_);
+        h_caloclusters_isSplit_->Fill(calocluster.isSplit_);
+      }
+    }
+
+    if (event.calohits != nullptr) {
+      std::cout << "Creating calohits histograms..." << std::endl;
+      for (const auto& calohit : *(event.calohits)) {
+
+        h_calohits_crystalId_->Fill(calohit.crystalId_);
+        h_calohits_nSiPMs_->Fill(calohit.nSiPMs_);
+        h_calohits_time_->Fill(calohit.time_);
+        h_calohits_timeErr_->Fill(calohit.timeErr_);
+        h_calohits_eDep_->Fill(calohit.eDep_);
+        h_calohits_eDepErr_->Fill(calohit.eDepErr_);
+        for (const auto& i_reco_digi : calohit.recoDigis_) {
+          h_calohits_recoDigis_->Fill(i_reco_digi);
+        }
+        h_calohits_clusterIdx_->Fill(calohit.clusterIdx_);
+      }
+    }
+
+    if (event.calorecodigis != nullptr) {
+      std::cout << "Creating calorecodigis histograms..." << std::endl;
+      for (const auto& calorecodigi : *(event.calorecodigis)) {
+        h_calorecodigis_eDep_->Fill(calorecodigi.eDep_);
+        h_calorecodigis_eDepErr_->Fill(calorecodigi.eDepErr_);
+        h_calorecodigis_time_->Fill(calorecodigi.time_);
+        h_calorecodigis_timeErr_->Fill(calorecodigi.timeErr_);
+        h_calorecodigis_chi2_->Fill(calorecodigi.chi2_);
+        h_calorecodigis_ndf_->Fill(calorecodigi.ndf_);
+        h_calorecodigis_pileUp_->Fill(calorecodigi.pileUp_);
+        h_calorecodigis_caloDigiIdx_->Fill(calorecodigi.caloDigiIdx_);
+        h_calorecodigis_caloHitIdx_->Fill(calorecodigi.caloHitIdx_);
+      }
+    }
+
+    if (event.calodigis != nullptr) {
+      std::cout << "Creating calodigis histograms..." << std::endl;
+      for (const auto& calodigi : *(event.calodigis)) {
+
+        h_calodigis_SiPMID_->Fill(calodigi.SiPMID_);
+        h_calodigis_t0_->Fill(calodigi.t0_);
+        for (const auto& i_waveform : calodigi.waveform_) {
+          h_calodigis_waveform_->Fill(i_waveform);
+        }
+        h_calodigis_peakpos_->Fill(calodigi.peakpos_);
+        h_calodigis_caloRecoDigiIdx_->Fill(calodigi.caloRecoDigiIdx_);
+      }
+    }
+
+
   }
-  
+
   file->Write();
   file->Close();
 }


### PR DESCRIPTION
This PR adds the new calorimeter branches to RooUtil. These can be accessed in the general ```event->branch.leaf``` way

It also adds a ```CaloCluster``` analyzer-friendly class, which only contains a link to a calorimeter cluster. It does not yet help analyzers access the underlying hits etc.