### PR TITLE
Add option to not create trkqual branch

### DIFF
--- a/fcl/from_mcs-extracted.fcl
+++ b/fcl/from_mcs-extracted.fcl
@@ -3,5 +3,6 @@
 physics.EventNtuplePath : [ @sequence::EventNtuple.PathExt ] # path for extracted position cosmics
 physics.analyzers.EventNtuple.branches : [ @local::Ext ]
 physics.analyzers.EventNtuple.FitType : KinematicLine
+physics.analyzers.EventNtuple.FillTrkQual : false
 
 services.GeometryService.inputFile: "Production/JobConfig/cosmic/geom_cosmic_extracted.txt"

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -270,6 +270,7 @@ EventNtupleMaker : {
   CrvCoincidenceClusterMCAssnsTag : "CrvCoincidenceClusterMCAssns"
   CrvPlaneY : @local::crvPlaneY.CRV_T
   FillMCInfo : true
+  FillTrkQual : true
   FillTrkPIDInfo : false
   FillHitInfo : true
   FillTriggerInfo : false

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -191,6 +191,7 @@ namespace mu2e {
         fhicl::Atom<art::InputTag> crvMCAssnsTag{ Name("CrvCoincidenceClusterMCAssnsTag"), Comment("art::InputTag for CrvCoincidenceClusterMCAssns")};
         // Pre-processed analysis info; are these redundant with the branch config ?
         fhicl::Atom<bool> filltrkpid{Name("FillTrkPIDInfo"),false};
+        fhicl::Atom<bool> filltrkqual{Name("FillTrkQual"),false};
       };
       typedef art::EDAnalyzer::Table<Config> Parameters;
 
@@ -461,7 +462,9 @@ namespace mu2e {
       if(_ftype == KinematicLine )_ntuple->Branch((branch+"segpars_kl.").c_str(),&_allKLIs.at(i_branch),_buffsize,_splitlevel);
       // TrkCaloHit: currently only 1
       _ntuple->Branch((branch+"calohit.").c_str(),&_allTCHIs.at(i_branch));
-      _ntuple->Branch((branch+"qual.").c_str(),&_allTrkQualResults.at(i_branch),_buffsize,_splitlevel);
+      if (_conf.filltrkqual()) {
+        _ntuple->Branch((branch+"qual.").c_str(),&_allTrkQualResults.at(i_branch),_buffsize,_splitlevel);
+      }
       if (_conf.filltrkpid() && i_branchConfig.options().filltrkpid()) {
         int n_trkpid_vars = TrkCaloHitPID::n_vars;
         for (int i_trkpid_var = 0; i_trkpid_var < n_trkpid_vars; ++i_trkpid_var) {


### PR DESCRIPTION
This PR adds an option to turn off the creation of the ```trkqual``` branch:

```
physics.analyzers.EventNtuple.FillTrkQual : true / false
```

This option is on by default and turned off in the ```fcl/from_mcs-extracted.fcl``` file

This fixes an issue in RooUtil when running on extracted datasets. The issue was that we don't run TrkQual for extracted datasets but we were still creating a ```trkqual``` branch. This branch was empty and not the same length as the main ```trk``` branch which causes RooUtil to crash when it tries to coherently loop through the track-related branches